### PR TITLE
If no total set percent to 0

### DIFF
--- a/src/widgets/views/Graph/GraphIndicator.tsx
+++ b/src/widgets/views/Graph/GraphIndicator.tsx
@@ -104,6 +104,8 @@ export const GraphIndicator = (props: GraphInidicatorProps) => {
         percent =
           Math.round((retrievedValue / totalRetrievedValue) * 100 * 100) / 100;
         setPercent(percent);
+      } else {
+        setPercent(0);
       }
 
       if (colorCondition) {


### PR DESCRIPTION
En alguns casos extranys el total d'elements és 0, per tant és correcte que no es calculi el percentatge, però ens fallava perquè en l'evaluació del les condicions, al no estar definit no ens arribava.

Amb això fem que si no hi ha total el posa a 0.

@mguellsegarra es millor fer-ho així o es pot inicialitzar a l'estat a 0?