### PR TITLE
Fix async summary results

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/ooui": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "files": [
     "dist",
     "src",

--- a/src/widgets/views/Tree.tsx
+++ b/src/widgets/views/Tree.tsx
@@ -147,21 +147,22 @@ function Tree(props: Props): React.ReactElement {
 
   const from = (page - 1) * limit + 1;
   const to = from - 1 + items.length;
-  const summary = !total
-    ? null
-    : total === 0
-    ? t("no_results")
-    : t("summary")
-        .replace("{from}", from?.toString())
-        .replace("{to}", to?.toString())
-        .replace("{total}", total?.toString());
+  const summary =
+    total === undefined
+      ? null
+      : total === 0
+      ? t("no_results")
+      : t("summary")
+          .replace("{from}", from?.toString())
+          .replace("{to}", to?.toString())
+          .replace("{total}", total?.toString());
 
   const pagination = () => {
     if (!showPagination || treeView.isExpandable) {
       return null;
     }
 
-    return loading ? null : !total ? (
+    return loading ? null : total === undefined ? (
       <Spin />
     ) : (
       <Row align="bottom" className="pb-4">


### PR DESCRIPTION
En @lcbautista reporta: 

```
m'hi trobo ara que quan es busca en un llistat i no es troba res, es queda l'animació del loading i no saps si realment ha acabat de buscar o no.
```

![Peek 21-09-2022 09-32](https://user-images.githubusercontent.com/5711443/191445582-34b4b051-315d-4541-8595-21ca901d0137.gif)

Aquesta PR ho soluciona.