### PR TITLE
Call method instead create new React element

### DIFF
--- a/src/widgets/custom/ButtonGroup.tsx
+++ b/src/widgets/custom/ButtonGroup.tsx
@@ -83,7 +83,7 @@ export const ButtonGroup = (props: ButtonGroupProps) => {
         type={primary ? "primary" : undefined}
         //danger={danger ? true : undefined} This works but typescript
         // doesn't accept
-        overlay={<Items ooui={secondaryButtons} />}
+        overlay={Items({ooui: secondaryButtons})}
       >
         {getButtonIcon()}
         {caption}


### PR DESCRIPTION
Fix the render of ButtonGroup calling `Items` instead of generating a new React Element

## After
![image](https://user-images.githubusercontent.com/294235/228203660-0cdbdc6f-1d0b-443d-9d79-ae095c095532.png)

## Before
![image](https://user-images.githubusercontent.com/294235/228204084-4aa32038-f99a-48e3-92e1-4bd31da4aa03.png)
