### PR TITLE
Error al retornar l'icona

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/ooui": "^0.17.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "files": [
     "dist",
     "src",

--- a/src/__tests__/iconMapper.test.ts
+++ b/src/__tests__/iconMapper.test.ts
@@ -2,14 +2,18 @@ import iconMapper from "../helpers/iconMapper";
 import * as Icons from "@ant-design/icons";
 
 describe("A IconMapper instance", () => {
-  test("should return the default icon when key not found", () => {
-    const defaultIcon = Icons.RightOutlined;
-    const icon = iconMapper("RANDOM_KEY");
-    expect(icon).toBe(defaultIcon);
+  test("should return undefined when key not found", () => {
+    const icon = iconMapper("foo-bar");
+    expect(icon).toBe(undefined);
   });
   test("should return proper help icon when requested", () => {
     const helpIcon = Icons.QuestionOutlined;
-    const icon = iconMapper("STOCK_HELP");
+    const icon = iconMapper("gtk-help");
     expect(icon).toBe(helpIcon);
   });
+  test("should replace all - for _", () => {
+    const findAndReplaceIcon = Icons.FileSearchOutlined;
+    const icon = iconMapper("gtk-find-and-replace");
+    expect(icon).toBe(findAndReplaceIcon);
+  })
 });

--- a/src/helpers/iconMapper.ts
+++ b/src/helpers/iconMapper.ts
@@ -102,7 +102,7 @@ const iconMapping: { [key: string]: string } = {
 
 export default (key: string) => {
   if (key.indexOf("gtk-") !== -1) {
-    const rootIcon = key.replace("gtk-", "").replace("-", "_");
+    const rootIcon = key.replace("gtk-", "").replace(/\-/g, "_");
     const newKey = `STOCK_${rootIcon.toUpperCase()}`;
     return getIconForKey(iconMapping[newKey]);
   }
@@ -114,8 +114,8 @@ export default (key: string) => {
   return getIconForKey(key);
 };
 
-function getIconForKey(key: string) {
-  const IconCamelCase = `${key
+function toCamelCase(key: string) : string  {
+  return `${key
     .split("-")
     .map((word) =>
       word.replace(
@@ -124,6 +124,12 @@ function getIconForKey(key: string) {
       )
     )
     .join("")}`;
+}
+
+function getIconForKey(IconCamelCase: string) {
+  if (IconCamelCase.indexOf("-") !== -1) {
+    IconCamelCase = toCamelCase(IconCamelCase);
+  }
 
   const antKey: AntKey = `${IconCamelCase}Outlined` as any;
   if (AntIcons[antKey]) {


### PR DESCRIPTION
Solucionem dos problemes:
- Quan hi havia un icona tipus `gtk-foo-bar` només es substituïa el primer `-` fent que fos `STOCK_FOO-BAR` i feia que no trobés l'icona
- Al introduïr el canvi de retornar strings en comptes del propi icona https://github.com/gisce/react-ooui/commit/4b70e7ca696cdb603bf47eb85aaea2aa2ce70753 i després convertir a *CamelCase* passava a ser `Camelcase` i això provocava que no trobés l'icona