### PR TITLE
Add Tag widget for form and tree

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,15 +1,15 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "1.1.31",
+      "version": "1.1.32",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
-        "@gisce/ooui": "^0.17.12",
+        "@gisce/ooui": "^0.17.13",
         "@gisce/react-formiga-table": "^0.5.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -2715,9 +2715,9 @@
       "dev": true
     },
     "node_modules/@gisce/ooui": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.17.12.tgz",
-      "integrity": "sha512-z82FWa3pskmn+WYhBCnwuN/AcpqI90Lj7hGw968TvcnZrQ5LuNjSpbsB8rLmqDFP9B29P+8mc6BHWVrWvKCPTA==",
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.17.13.tgz",
+      "integrity": "sha512-xBOAEsEmnO3Rt3+AxMGMBE8eplCno8qq37OmyeXUjZKURPl0wQc3gzLsO47ak+Lm/2106vRMZDij80kURCW6TQ==",
       "dependencies": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"
@@ -30678,9 +30678,9 @@
       "dev": true
     },
     "@gisce/ooui": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.17.12.tgz",
-      "integrity": "sha512-z82FWa3pskmn+WYhBCnwuN/AcpqI90Lj7hGw968TvcnZrQ5LuNjSpbsB8rLmqDFP9B29P+8mc6BHWVrWvKCPTA==",
+      "version": "0.17.13",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.17.13.tgz",
+      "integrity": "sha512-xBOAEsEmnO3Rt3+AxMGMBE8eplCno8qq37OmyeXUjZKURPl0wQc3gzLsO47ak+Lm/2106vRMZDij80kURCW6TQ==",
       "requires": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "files": [
     "dist",
     "src",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
-    "@gisce/ooui": "^0.17.12",
+    "@gisce/ooui": "^0.17.13",
     "@gisce/react-formiga-table": "^0.5.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",

--- a/src/helpers/treeHelper.ts
+++ b/src/helpers/treeHelper.ts
@@ -28,7 +28,7 @@ const getTableColumns = (
 
     if (component) {
       render = (item: any) => {
-        return component(item, key, tree.fields[key], context);
+        return component(item, key, column, context);
       };
     }
 
@@ -68,7 +68,7 @@ const getTableItems = (treeOoui: TreeOoui, results: Array<any>): Array<any> => {
           parsedItem[key] = item[key];
         } else if (widget instanceof Selection) {
           const selection = widget;
-          parsedItem[key] = selection.selectionValues.get(item[key]);
+          parsedItem[key] = item[key];
         } else if (widget instanceof Many2one) {
           parsedItem[key] = item[key] &&
             Array.isArray(item[key]) &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { Image } from "@/widgets/base/Image";
 import showConfirmDialog from "@/ui/ConfirmDialog";
 import Dashboard from "@/widgets/views/Dashboard/Dashboard";
 import { Tags } from "@/widgets/custom/Tags";
+import { Tag } from "@/widgets/custom/Tag";
 import { MultiCheckbox } from "./widgets/custom/MultiCheckbox";
 import { Radio } from "@/widgets/custom/Radio";
 import { Switch } from "@/widgets/custom/Switch";
@@ -144,6 +145,7 @@ export {
   DashboardGridItem,
   DashboardGrid,
   Tags,
+  Tag,
   MultiCheckbox,
   Radio,
   Switch,

--- a/src/stories/custom/Tag.stories.tsx
+++ b/src/stories/custom/Tag.stories.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { Tag as TagOoui } from "@gisce/ooui";
+import "antd/dist/antd.css";
+import LocaleProvider from "../../context/LocaleContext";
+import { TagInput } from "../../widgets/custom/Tag";
+
+export default {
+  title: "Components/Widgets/Custom/Tag",
+};
+
+export const Default = (): React.ReactElement => {
+  const ooui = new TagOoui({
+    name: "status",
+    string: "Status",
+    field: "status",
+    selection: [['draft', 'Draft'], ['open', 'Open']],
+    widget_props: '{"colors": {"draft": "blue", "open": "green"}}'
+  });
+
+  return (
+    <LocaleProvider lang="en_US">
+     <TagInput value="draft" ooui={ooui}/>
+    </LocaleProvider>
+  );
+};
+
+export const WithoutColor = (): React.ReactElement => {
+  const ooui = new TagOoui({
+    name: "status",
+    string: "Status",
+    field: "status",
+    selection: [['draft', 'Draft'], ['open', 'Open']],
+  });
+
+  return (
+    <LocaleProvider lang="en_US">
+     <TagInput value="draft" ooui={ooui}/>
+    </LocaleProvider>
+  );
+};
+
+export const WithColorAuto = (): React.ReactElement => {
+  const ooui = new TagOoui({
+    name: "status",
+    string: "Status",
+    field: "status",
+    selection: [['draft', 'Draft'], ['open', 'Open']],
+    widget_props: '{"colors": "auto"}'
+  });
+
+  return (
+    <LocaleProvider lang="en_US">
+     <TagInput value="draft" ooui={ooui}/>
+    </LocaleProvider>
+  );
+};

--- a/src/stories/views/Tree.stories.jsx
+++ b/src/stories/views/Tree.stories.jsx
@@ -30,7 +30,7 @@ Default.args = {
       lang: false,
       name: "AGRI ENERGIA ELECTRICA, S.A.",
       ref: "0112",
-      title: false,
+      title: "corp",
       numeric: 30.1,
       progressbar: 100,
     },
@@ -41,7 +41,7 @@ Default.args = {
       lang: false,
       name: "Agrolait",
       ref: false,
-      title: false,
+      title: "ltd",
       numeric: 30.1,
       progressbar: 70.434331,
     },
@@ -85,14 +85,14 @@ Default.args = {
       lang: false,
       name: "Aragón",
       ref: "02",
-      title: false,
+      title: "corp",
       numeric: 30.1,
       progressbar: 20.01,
     },
   ],
   treeView: {
     arch:
-      '<tree string="Partners">\n<field name="numeric" sum="Numeric"/><field name="name"/>\n                    <field name="title"/>\n                    <field name="ref"/>\n                    <field name="city" select="2"/>\n                    <field name="country" select="2"/>\n                    <field name="lang"/>\n <field name="progressbar" string="Progress" />               </tree>',
+      `<tree string="Partners">\n<field name="numeric" sum="Numeric"/><field name="name"/>\n                    <field name="title" widget="tag" widget_props="{'colors': {'corp': 'red', 'ltd': 'green'}}"/>\n                    <field name="ref"/>\n                    <field name="city" select="2"/>\n                    <field name="country" select="2"/>\n                    <field name="lang"/>\n <field name="progressbar" string="Progress" />               </tree>`,
     fields: {
       progressbar: {
         string: "Progress bar",
@@ -149,7 +149,7 @@ Default.args = {
       },
       title: {
         selection: [
-          ["Corp.", "Corp."],
+          ["corp", "Corp."],
           ["ltd", "Ltd"],
           ["", ""],
         ],

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -29,6 +29,7 @@ import {
   Radio,
   Switch,
   Steps,
+  Tag,
   CodeEditor,
 } from "@/index";
 import { Image } from "./base/Image";
@@ -99,6 +100,8 @@ const getWidgetType = (type: string) => {
       return Indicator;
     case "tags":
       return Tags;
+    case "tag":
+      return Tag;
     case "multicheckbox":
       return MultiCheckbox;
     case "radio":

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -14,6 +14,9 @@ export const Tag = (props: WidgetProps) => {
 
 export const TagInput = (props) => {
   const {ooui, value} = props;
+  if (!value) {
+    return null
+  }
   const color = ooui.colors === "auto" ? colorFromString(value) : ooui.colors[value]
   return (
     <AntdTag color={color}>{ooui.selectionValues.get(value)}</AntdTag>

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -1,0 +1,21 @@
+import Field from "@/common/Field";
+import { WidgetProps } from "@/types";
+import { Tag as AntdTag } from 'antd';
+import { colorFromString } from "@/helpers/formHelper";
+
+
+export const Tag = (props: WidgetProps) => {
+  return (
+    <Field {...props}>
+      <TagInput {...props}/>
+    </Field>
+  );
+};
+
+export const TagInput = (props) => {
+  const {ooui, value} = props;
+  const color = ooui.colors === "auto" ? colorFromString(value) : ooui.colors[value]
+  return (
+    <AntdTag color={color}>{ooui.selectionValues.get(value)}</AntdTag>
+  );
+}

--- a/src/widgets/views/Tree.tsx
+++ b/src/widgets/views/Tree.tsx
@@ -111,8 +111,6 @@ value: any,
   ooui: any,
   context: any
 ): React.ReactElement => {
-  console.log(value);
-  console.log(ooui);
   return (
     <>{ooui.selectionValues.get(value)}</>
   );

--- a/src/widgets/views/Tree.tsx
+++ b/src/widgets/views/Tree.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { Pagination, Checkbox, Space, Row, Col, Spin } from "antd";
+import { Pagination, Checkbox, Space, Row, Col, Spin, Tag } from "antd";
 import { getTree, getTableColumns, getTableItems } from "@/helpers/treeHelper";
 import { Tree as TreeOoui } from "@gisce/ooui";
 
@@ -92,17 +92,43 @@ const imageComponent = (value: string): React.ReactElement => {
   );
 };
 
+const TagComponent = (
+value: any,
+  key: string,
+  ooui: any,
+  context: any
+): React.ReactElement => {
+  return (
+    <>
+      <Tag color={ooui.colors[value]}>{ooui.selectionValues.get(value)}</Tag>
+    </>
+  );
+};
+
+const SelectionComponent = (
+value: any,
+  key: string,
+  ooui: any,
+  context: any
+): React.ReactElement => {
+  console.log(value);
+  console.log(ooui);
+  return (
+    <>{ooui.selectionValues.get(value)}</>
+  );
+};
+
 const referenceComponent = (
   value: any,
   key: string,
-  fieldDefinitions: any,
+  ooui: any,
   context: any
 ): React.ReactElement => {
   return (
     <>
       <ReferenceTree
         value={value}
-        selectionValues={new Map(fieldDefinitions?.selection)}
+        selectionValues={ooui.selectionValues}
         context={context}
       />
     </>
@@ -164,6 +190,8 @@ function Tree(props: Props): React.ReactElement {
         integer: numberComponent,
         float: numberComponent,
         reference: referenceComponent,
+        tag: TagComponent,
+        selection: SelectionComponent,
       },
       context
     );

--- a/src/widgets/views/Tree.tsx
+++ b/src/widgets/views/Tree.tsx
@@ -100,7 +100,7 @@ value: any,
 ): React.ReactElement => {
   return (
     <>
-      <Tag color={ooui.colors[value]}>{ooui.selectionValues.get(value)}</Tag>
+      {value ? <Tag color={ooui.colors[value]}>{ooui.selectionValues.get(value)}</Tag> : null}
     </>
   );
 };


### PR DESCRIPTION
Requires https://github.com/gisce/ooui.js/pull/74

![image](https://user-images.githubusercontent.com/294235/229753802-c19b428d-252f-4afc-901b-595574c60936.png)


## Com fer-la servir

```xml
<tree string="Partners">
    <field name="numeric" sum="Numeric"/>
    <field name="name"/>
    <field name="title" widget="tag" widget_props="{'colors': {'corp': 'red', 'ltd': 'green'}}"/>
    <field name="ref"/>
    <field name="city" select="2"/>
    <field name="country" select="2"/>
    <field name="lang"/>
    <field name="progressbar" string="Progress" />
</tree>
```
### Colors:

Podem fer els pre-definits a ant: `magenta, red, volcano, orange, gold, lime, green, cyan, blue, geekblue, purple`, podem no posar color i ho farà amb gris, o bé li podem posar `widget_props="{'colors': 'auto'}"` i generarà un color hexadacimal de forma automàtica segons el valor del camp

ℹ️ Informació del widget a https://ant.design/components/tag