### PR TITLE
Fix separator space

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "1.1.52",
+      "version": "1.1.53",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/ooui": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "files": [
     "dist",
     "src",

--- a/src/stories/Separator.stories.tsx
+++ b/src/stories/Separator.stories.tsx
@@ -20,6 +20,27 @@ export const Default = (): React.ReactElement => {
   );
 };
 
+export const WithoutText = (): React.ReactElement => {
+  const ooui = new SeparatorOoui({
+  });
+  return (
+    <LocaleProvider lang="en_US">
+      <Separator ooui={ooui} showLabel />
+    </LocaleProvider>
+  );
+};
+
+export const OnlyIcon = (): React.ReactElement => {
+  const ooui = new SeparatorOoui({
+    icon: "home"
+  });
+  return (
+    <LocaleProvider lang="en_US">
+      <Separator ooui={ooui} showLabel />
+    </LocaleProvider>
+  );
+};
+
 export const WithIcon = (): React.ReactElement => {
   const ooui = new SeparatorOoui({
     string: "General",

--- a/src/stories/containers/Group.stories.tsx
+++ b/src/stories/containers/Group.stories.tsx
@@ -73,3 +73,15 @@ export const WithIcon = (): React.ReactElement => {
     </LocaleProvider>
   );
 };
+
+
+export const OnlyIcon = (): React.ReactElement => {
+  const ooui = new GroupOoui({
+    icon: "home"
+  });
+  return (
+    <LocaleProvider lang="en_US">
+      <Group ooui={ooui} />
+    </LocaleProvider>
+  );
+};

--- a/src/widgets/base/Separator.tsx
+++ b/src/widgets/base/Separator.tsx
@@ -15,10 +15,12 @@ export const Separator = (props: Props) => {
 
   return (
     <Divider orientation="left" className="text-sm">
-      <Space>
-        {Icon ? <Icon /> : null}
-        {label}
-      </Space>
+      { (Icon || label) &&
+        <Space>
+          {Icon ? <Icon /> : null}
+          {label}
+        </Space>
+      }
     </Divider>
   );
 };

--- a/src/widgets/containers/Group.tsx
+++ b/src/widgets/containers/Group.tsx
@@ -23,7 +23,7 @@ function Group(props: Props): React.ReactElement {
 
   return (
     <>
-      {ooui.label && showLabel ? (
+      {(ooui.label || Icon) && showLabel ? (
         <Fieldset label={label}>
           <Container
             container={ooui!.container}


### PR DESCRIPTION
Si no hi havia text ni icona, deixava un espai igualment.

![image](https://github.com/gisce/react-ooui/assets/294235/87b33eb5-120b-40c3-88ee-f420dcef425b)

## Separador
- No deixa espai si no hi ha text ni icona
- Es permet fer separadors on només hi hagi icona

## Groups
- Es permet un group on només hi hagi icona

