### PR TITLE
Raise errors in build time, strictly checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "prerelease": "npm version prerelease --preid rc",
     "prepatch": "npm version prepatch --preid rc",
     "premajor": "npm version premajor --preid rc",
-    "start": "while :; do vite build --watch --force; done",
+    "start": "while :; do tsc && vite build --watch --force; done",
     "build:tailwind": "postcss src/tailwind.css -o src/tailwind.generated.css",
-    "build": "vite build",
+    "build": "tsc && vite build",
     "test": "jest",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -1,8 +1,8 @@
+import React from "react";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { Tag as AntdTag } from 'antd';
 import { colorFromString } from "@/helpers/formHelper";
-
 
 export const Tag = (props: WidgetProps) => {
   return (
@@ -12,7 +12,7 @@ export const Tag = (props: WidgetProps) => {
   );
 };
 
-export const TagInput = (props) => {
+export const TagInput = (props: any) => {
   const {ooui, value} = props;
   if (!value) {
     return null


### PR DESCRIPTION
When running `npx tsc`, it raises errors when for example a component has missing props.

When running vite it doesn't raise any errors.

This will ensure that when in development time or build time it raises errors.