### PR TITLE
Improve Markdown widget

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,15 +1,15 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "1.1.60",
+      "version": "1.1.61",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
-        "@gisce/ooui": "^0.19.3",
+        "@gisce/ooui": "^0.19.4",
         "@gisce/react-formiga-table": "^0.5.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -2716,9 +2716,9 @@
       "dev": true
     },
     "node_modules/@gisce/ooui": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.19.3.tgz",
-      "integrity": "sha512-wHn7cFX8su7nuVh55wCKM6C139c6aoP0s+FY6kfvSJbw3QrlLgHZSidm7EwfelCNHneJKNH1qfWcfYjXGQsQWA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.19.4.tgz",
+      "integrity": "sha512-i9X4l1ZzpInAVbYIejnGSO5PlP7m8OK6e7r0nNy1ONcG0sNY6L+uTF2z7VJWVk8s3EXMdmAcfGQSMhxGi8Ylxg==",
       "dependencies": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"
@@ -31695,9 +31695,9 @@
       "dev": true
     },
     "@gisce/ooui": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.19.3.tgz",
-      "integrity": "sha512-wHn7cFX8su7nuVh55wCKM6C139c6aoP0s+FY6kfvSJbw3QrlLgHZSidm7EwfelCNHneJKNH1qfWcfYjXGQsQWA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-0.19.4.tgz",
+      "integrity": "sha512-i9X4l1ZzpInAVbYIejnGSO5PlP7m8OK6e7r0nNy1ONcG0sNY6L+uTF2z7VJWVk8s3EXMdmAcfGQSMhxGi8Ylxg==",
       "requires": {
         "html-entities": "^2.3.3",
         "moment": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "files": [
     "dist",
     "src",
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
-    "@gisce/ooui": "^0.19.3",
+    "@gisce/ooui": "^0.19.4",
     "@gisce/react-formiga-table": "^0.5.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",

--- a/src/widgets/custom/Markdown.tsx
+++ b/src/widgets/custom/Markdown.tsx
@@ -12,8 +12,11 @@ export  const Markdown = (props: WidgetProps) => {
 };
 
 export const MarkdownInput = (props: any) => {
-  const {value} = props;
+  const {value, ooui} = props;
   return (
-    <ReactMarkdown children={value}/>
+    <div style={{height: ooui.height ? ooui.height + 'px' : '100%'}}>
+      <ReactMarkdown children={value} />
+    </div>
+
   )
 }

--- a/src/widgets/custom/Markdown.tsx
+++ b/src/widgets/custom/Markdown.tsx
@@ -15,7 +15,7 @@ export const MarkdownInput = (props: any) => {
   const {value, ooui} = props;
   return (
     <div style={{height: ooui.height ? ooui.height + 'px' : '100%'}}>
-      <ReactMarkdown children={value} />
+      <ReactMarkdown children={value} className="ant-typography"/>
     </div>
 
   )


### PR DESCRIPTION
- Add a div with height
- Add `.ant-typography` class to fix text style
![image](https://github.com/gisce/react-ooui/assets/294235/97b083d8-a61a-4b0d-97b5-43cdcec0f8f5)
