### PR TITLE
Clear tree selected row keys when refreshing

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "^1.1.0-rc.3",
         "@gisce/ooui": "^0.22.2",
         "@gisce/react-formiga-components": "^1.0.9-rc.21",
-        "@gisce/react-formiga-table": "^0.8.4",
+        "@gisce/react-formiga-table": "^0.8.5-rc.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "^5.5.2",
@@ -2751,13 +2751,14 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-0.8.4.tgz",
-      "integrity": "sha512-R8FWd0VFM9g2iDH9xXv+54851fAu68T+NVcbEERZxUj5aH4MH8BmLfj/M4ghmS1mwWm/XLSGybKb5R6tg0iUkQ==",
+      "version": "0.8.5-rc.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-0.8.5-rc.0.tgz",
+      "integrity": "sha512-YQINngNB74yaJKfE3Nfd8X9V4EhAhdT+1yeuddPQ+Nux57DBiVGhrDIideZh6Wm/ftJNVDaGRH6U0s82oUG7uA==",
       "dependencies": {
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x",
-        "styled-components": "^5.0.0"
+        "styled-components": "^5.0.0",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
@@ -31560,13 +31561,14 @@
       }
     },
     "@gisce/react-formiga-table": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-0.8.4.tgz",
-      "integrity": "sha512-R8FWd0VFM9g2iDH9xXv+54851fAu68T+NVcbEERZxUj5aH4MH8BmLfj/M4ghmS1mwWm/XLSGybKb5R6tg0iUkQ==",
+      "version": "0.8.5-rc.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-0.8.5-rc.0.tgz",
+      "integrity": "sha512-YQINngNB74yaJKfE3Nfd8X9V4EhAhdT+1yeuddPQ+Nux57DBiVGhrDIideZh6Wm/ftJNVDaGRH6U0s82oUG7uA==",
       "requires": {
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x",
-        "styled-components": "^5.0.0"
+        "styled-components": "^5.0.0",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "dependencies": {
         "react": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@gisce/fiber-diagram": "^1.1.0-rc.3",
     "@gisce/ooui": "^0.22.2",
     "@gisce/react-formiga-components": "^1.0.9-rc.21",
-    "@gisce/react-formiga-table": "^0.8.4",
+    "@gisce/react-formiga-table": "^0.8.5-rc.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "^5.5.2",

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -264,6 +264,7 @@ export const useSearch = (opts: UseSearchOpts) => {
       } catch (error) {
         setSearchError(error.message);
       } finally {
+        setSelectedRowItems?.([]);
         setSearchFilterLoading(false);
         setTreeIsLoading?.(false);
       }

--- a/src/widgets/views/SearchTree.tsx
+++ b/src/widgets/views/SearchTree.tsx
@@ -128,7 +128,7 @@ function SearchTree(props: Props, ref: any) {
   } = useSearch({
     model: currentModel!,
     setSearchTreeNameSearch,
-    setSelectedRowItems,
+    setSelectedRowItems: changeSelectedRowKeys,
     setSearchParams,
     setSearchValues,
     searchParams,

--- a/src/widgets/views/Tree.tsx
+++ b/src/widgets/views/Tree.tsx
@@ -365,6 +365,7 @@ function Tree(props: Props): React.ReactElement {
             : undefined
         }
         onRowDoubleClick={onRowClicked}
+        selectionRowKeys={rowSelection?.selectedRowKeys}
         onRowSelectionChange={rowSelection?.onChange}
         onChangeSort={onChangeSort}
         sorter={sorter}


### PR DESCRIPTION
Related https://github.com/gisce/webclient/issues/576
depends on: https://github.com/gisce/react-formiga-table/pull/15