### PR TITLE
Add a new HTMLPreview widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { Switch } from "@/widgets/custom/Switch";
 import { Steps } from "@/widgets/custom/Steps";
 import { CodeEditor } from "@/widgets/custom/CodeEditor";
 import { CommentsTimelineField } from "@/widgets/custom/Comments";
+import { HTMLPreview } from "@/widgets/custom/HTMLPreview";
 import {
   DashboardGridItem,
   DashboardGrid,
@@ -171,4 +172,5 @@ export {
   ErpFeatureKeys,
   ErpFeaturesMap,
   ConfigContextProvider,
+  HTMLPreview,
 };

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -34,6 +34,7 @@ import {
   Tag,
   CodeEditor,
   CommentsTimelineField,
+  HTMLPreview,
 } from "@/index";
 import { Image } from "./base/Image";
 import { FiberGrid } from "./custom/FiberGrid";
@@ -121,6 +122,8 @@ const getWidgetType = (type: string) => {
       return CodeEditor;
     case "comments_timeline":
       return CommentsTimelineField;
+    case "html_preview":
+      return HTMLPreview;
     default:
       return undefined;
   }

--- a/src/widgets/custom/HTMLPreview.tsx
+++ b/src/widgets/custom/HTMLPreview.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Field from "@/common/Field";
+import { HTMLPreview as HTMLPreviewInput } from "@gisce/react-formiga-components";
+import { WidgetProps } from "@/types";
+
+export const HTMLPreview = (props: WidgetProps) => {
+  return (
+    <Field {...props}>
+      <HTMLPreviewInput />
+    </Field>
+  );
+};


### PR DESCRIPTION
- Depends on https://github.com/gisce/react-formiga-components/pull/3
- Depends on https://github.com/gisce/ooui/pull/110
- Closes https://github.com/gisce/webclient/issues/566

Use:

```xml
<field name="body_html" widget="html_preview" />
```