### PR TITLE
feat(widget): add new alert widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.5.0",
+        "@gisce/ooui": "2.6.0",
         "@gisce/react-formiga-components": "1.6.2",
         "@gisce/react-formiga-table": "1.2.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3367,9 +3367,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.5.0.tgz",
-      "integrity": "sha512-gG3te1kGuNHVulgWfOu1/UlFw/ziL3fLHvjttePnOV+MjrmlvxAZvAuToWbHimvlMCAeZf20ZpUrClaYhSl8pw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.6.0.tgz",
+      "integrity": "sha512-L//ADaQZ00JBx3QLcwPFRZ+URiGRlLW8QEr+49pEGOyJv4btpOeTrvhdhmq+0ExhhTUXxLVKz5il7D0BygRRhw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.5.0",
+    "@gisce/ooui": "2.6.0",
     "@gisce/react-formiga-components": "1.6.2",
     "@gisce/react-formiga-table": "1.2.0",
     "@monaco-editor/react": "^4.4.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { Steps } from "@/widgets/custom/Steps";
 import { CodeEditor } from "@/widgets/custom/CodeEditor";
 import { CommentsTimelineField } from "@/widgets/custom/Comments";
 import { HTMLPreview } from "@/widgets/custom/HTMLPreview";
+import { Alert } from "@/widgets/custom/Alert";
 import {
   DashboardGridItem,
   DashboardGrid,
@@ -173,4 +174,5 @@ export {
   ErpFeaturesMap,
   ConfigContextProvider,
   HTMLPreview,
+  Alert,
 };

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -35,6 +35,7 @@ import {
   CodeEditor,
   CommentsTimelineField,
   HTMLPreview,
+  Alert,
 } from "@/index";
 import { Image } from "./base/Image";
 import { FiberGrid } from "./custom/FiberGrid";
@@ -124,6 +125,8 @@ const getWidgetType = (type: string) => {
       return CommentsTimelineField;
     case "html_preview":
       return HTMLPreview;
+    case "alert":
+      return Alert;
     default:
       return undefined;
   }

--- a/src/widgets/custom/Alert.tsx
+++ b/src/widgets/custom/Alert.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Alert as AntdAlert } from "antd";
+import { WidgetProps } from "@/types";
+import { Alert as AlertOoui } from "@gisce/ooui";
+import { Interweave } from "interweave";
+import iconMapper from "@/helpers/iconMapper";
+
+export const Alert = (props: WidgetProps) => {
+  const { ooui } = props;
+  const { title, text, alertType, icon } = ooui as AlertOoui;
+
+  function getIcon(icon: string): React.JSX.Element | undefined {
+    if (icon) {
+      const Icon: React.ElementType = iconMapper(icon) as any;
+      return Icon && <Icon />;
+    }
+    return undefined;
+  }
+
+  return (
+    <AntdAlert
+      message={<Interweave content={title} />}
+      description={<Interweave content={text} />}
+      type={alertType}
+      showIcon
+      icon={getIcon(icon)}
+    />
+  );
+};

--- a/src/widgets/custom/Alert.tsx
+++ b/src/widgets/custom/Alert.tsx
@@ -9,7 +9,7 @@ export const Alert = (props: WidgetProps) => {
   const { ooui } = props;
   const { title, text, alertType, icon } = ooui as AlertOoui;
 
-  function getIcon(icon: string): React.JSX.Element | undefined {
+  function getIcon(icon: string | null): React.JSX.Element | undefined {
     if (icon) {
       const Icon: React.ElementType = iconMapper(icon) as any;
       return Icon && <Icon />;


### PR DESCRIPTION
Depends on https://github.com/gisce/ooui/pull/114

Add a new widget based on [Ant Alert](https://ant.design/components/alert/)


```xml
<alert colspan="6" alert_type="error" title="Atenció" text="Aquest és un impagador!"/>
```

![image](https://github.com/gisce/react-ooui/assets/294235/66f621d9-5577-4d57-ae27-cd2308ecffa4)


Closes https://github.com/gisce/webclient/issues/1024