### PR TITLE
update gisce/ooui to v2.10.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.10.0-alpha.2",
+        "@gisce/ooui": "2.10.0-alpha.3",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.6.0-alpha.11",
         "@monaco-editor/react": "^4.4.5",
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.10.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.0-alpha.2.tgz",
-      "integrity": "sha512-/61IVazutFc4h+XW6l/zhbBlBYQP/SABo5VE/9KIluGNP9rg1oosCYFOy6woWkq4n1KihTvA5Hzs52xJoxZ0IQ==",
+      "version": "2.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.0-alpha.3.tgz",
+      "integrity": "sha512-WDIKHdx4KgbLZkKCD0crAs1Ao/e0QxWPGVjeg6lo5opV8tipgvYWSkO2+JmJzckZMQlPuKQQhSNGyik2fb0KRA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.10.0-alpha.2",
+    "@gisce/ooui": "2.10.0-alpha.3",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.6.0-alpha.11",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.10.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.10.0-alpha.3).