### PR TITLE
update gisce/react-formiga-table to v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.9.0",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.5.0",
+        "@gisce/react-formiga-table": "1.5.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "5.13.1",
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.5.0.tgz",
-      "integrity": "sha512-zuRr/3ClRI6R9B4KRnKDFzU8vN7pkUGEslkDWCI27YEObuOPaekT6wCo1fODeWXR5Z+QKENmTONFtAZQKdpHJg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.5.1.tgz",
+      "integrity": "sha512-v5PwlqwawCyL3ikrklIQgMot8sWKMzKGKGvkjAqTpm47b66j3O8gMi+sIR5VAJ4WKc0XvvTIJAfEmHhtGoHLLw==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.9.0",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.5.0",
+    "@gisce/react-formiga-table": "1.5.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "5.13.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.5.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.5.1).