### PR TITLE
update gisce/react-formiga-table to v1.6.0-alpha.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.10.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.6.0-alpha.11",
+        "@gisce/react-formiga-table": "1.6.0-alpha.12",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "5.13.1",
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.6.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.6.0-alpha.11.tgz",
-      "integrity": "sha512-wWYNpOf3Z2bHEv3RuVEJPfVdHF2g4dCi74+Q3RBcmeETDfSoAOVJP3VXNhrPXe18fCBy6HlVGWI0hgiJBgFvJA==",
+      "version": "1.6.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.6.0-alpha.12.tgz",
+      "integrity": "sha512-n+6YSn4N+6hKsl2n87LN9d6KE7duAYlvFPmScqgnpmhRjwank3uKLYCm3Y1GHW8DRMydECz+6lXq+UtJ+Ptgng==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.10.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.6.0-alpha.11",
+    "@gisce/react-formiga-table": "1.6.0-alpha.12",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "5.13.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.6.0-alpha.12](https://github.com/gisce/react-formiga-table/releases/tag/v1.6.0-alpha.12).