### PR TITLE
update gisce/react-formiga-components to v1.9.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.10.0-alpha.2",
-        "@gisce/react-formiga-components": "1.8.0",
+        "@gisce/react-formiga-components": "1.9.0-alpha.2",
         "@gisce/react-formiga-table": "1.6.0-alpha.11",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.8.0.tgz",
-      "integrity": "sha512-bsLp9sa4WEGgHsb/jhog5JRDDgKwgtkouw11ZQD86SdRS5hhO4Ri1gVmmPUO8dM4wLZdOBst1S//4o4jYb9pHw==",
+      "version": "1.9.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.9.0-alpha.2.tgz",
+      "integrity": "sha512-U3pg31695AU5iX+7V+WuC9LHWjooUktCqNzJQ2m+Mmi0adAkfL+pTUOAFDzHcxb5z827S6GnPAh+Oq64O9sHCQ==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.10.0-alpha.2",
-    "@gisce/react-formiga-components": "1.8.0",
+    "@gisce/react-formiga-components": "1.9.0-alpha.2",
     "@gisce/react-formiga-table": "1.6.0-alpha.11",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.9.0-alpha.2](https://github.com/gisce/react-formiga-components/releases/tag/v1.9.0-alpha.2).