### PR TITLE
update gisce/fiber-diagram to v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.17.2",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
-        "@gisce/fiber-diagram": "2.1.1",
+        "@gisce/fiber-diagram": "2.1.2",
         "@gisce/ooui": "2.9.0",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.5.0",
@@ -3349,9 +3349,9 @@
       }
     },
     "node_modules/@gisce/fiber-diagram": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@gisce/fiber-diagram/-/fiber-diagram-2.1.1.tgz",
-      "integrity": "sha512-+nbnIgoAnXKAJmbZkftkULx2ZYa182+s5/u4d5BNRbLgdMkPJRUwEFAhOEZt8psL0OPSfvmBlAzuqM2MJjo71w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gisce/fiber-diagram/-/fiber-diagram-2.1.2.tgz",
+      "integrity": "sha512-MHH68jWQhK4FXap4ZfmR4OcNzh/JhKHFHxJla/J8rw4Ss1QagMfUCsUxQ3iqna+zz/6EZ9kIQmvbOjnLLKoPlw==",
       "dependencies": {
         "antd": "5.13.1",
         "konva": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
-    "@gisce/fiber-diagram": "2.1.1",
+    "@gisce/fiber-diagram": "2.1.2",
     "@gisce/ooui": "2.9.0",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.5.0",


### PR DESCRIPTION
This PR updates [gisce/fiber-diagram](https://github.com/gisce/fiber-diagram) to [v2.1.2](https://github.com/gisce/fiber-diagram/releases/tag/v2.1.2).