### PR TITLE
update gisce/ooui to v2.10.1-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.10.0",
+        "@gisce/ooui": "2.10.1-rc.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.5.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.0.tgz",
-      "integrity": "sha512-8MqJR5Uu0WYkaBLb/sL6k6vnE1l9yDymXxu/+czXzmFz6nomGAMFew0nSOw1AqmObtHRIWLe9W5LnrD70lsc7A==",
+      "version": "2.10.1-rc.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.1-rc.1.tgz",
+      "integrity": "sha512-yosmf1SRYXIJxhdBol6MVD/KzoKWRefsiCwtL3FYF3zlpXu+nrKVZECdqk9SSp/5mIdtlKaTGpoBBNS70rH3/g==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.10.0",
+    "@gisce/ooui": "2.10.1-rc.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.5.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.10.1-rc.1](https://github.com/gisce/ooui/releases/tag/v2.10.1-rc.1).