### PR TITLE
update gisce/react-formiga-table to v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.10.1",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.5.0",
+        "@gisce/react-formiga-table": "1.6.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "5.13.1",
@@ -3407,12 +3407,13 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.5.0.tgz",
-      "integrity": "sha512-zuRr/3ClRI6R9B4KRnKDFzU8vN7pkUGEslkDWCI27YEObuOPaekT6wCo1fODeWXR5Z+QKENmTONFtAZQKdpHJg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.6.0.tgz",
+      "integrity": "sha512-Q6LJxxSm0XA6NQWZJoXPbNdktgoFO9+xoSvPAvfJ5knJAfwM/0oGAwkx++Wbcn8LUyP3b51CfZ26VzJKEzxgwQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",
+        "dequal": "^2.0.3",
         "lodash.debounce": "^4.0.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.10.1",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.5.0",
+    "@gisce/react-formiga-table": "1.6.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "5.13.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.6.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.6.0).