### PR TITLE
update gisce/ooui to v2.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.10.1",
+        "@gisce/ooui": "2.10.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.5.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.1.tgz",
-      "integrity": "sha512-uHl3HrF9GmIMuLmjHh2X2Ihhq8lyw/9GMDayLbZTCcwf+jScqaHcS1GcaXNmJGYu4KJgRcmX7Xom+6b3+UvWyg==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.2.tgz",
+      "integrity": "sha512-eYbLUxhw5KAi4ne3fgcJY7zQ6gxWCnfswsros6yA4f1O/IVwllpBwC1szKpEkZuQrPmax19eLqFNDLi5ktf3fQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.10.1",
+    "@gisce/ooui": "2.10.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.5.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.10.2](https://github.com/gisce/ooui/releases/tag/v2.10.2).