### PR TITLE
update gisce/react-formiga-table to v1.7.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.10.1-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.6.0-alpha.14",
+        "@gisce/react-formiga-table": "1.7.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "5.13.1",
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.6.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.6.0-alpha.14.tgz",
-      "integrity": "sha512-zZBSRFJbEi3aKbcJvMm7Y/13I75xHetuOqUF7rJ1d/3au7WpJpREvleAmhFmQBwCxVLk0x/3KFjNzORm0Fc8vA==",
+      "version": "1.7.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0-alpha.1.tgz",
+      "integrity": "sha512-CjaaTZgU0rZbRfuX4p3660QGDYFtYp94uE8swjV58r2VQU8y0AAhvW58tJitzShkdhoGjmLuV2F/Y22anZx9bg==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.10.1-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.6.0-alpha.14",
+    "@gisce/react-formiga-table": "1.7.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "5.13.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.7.0-alpha.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.7.0-alpha.1).