### PR TITLE
update gisce/ooui to v2.11.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.10.1-alpha.1",
+        "@gisce/ooui": "2.11.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.6.0-alpha.14",
         "@monaco-editor/react": "^4.4.5",
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.10.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.10.1-alpha.1.tgz",
-      "integrity": "sha512-Yf8aG1x9aoy0yk9L+5AkhE5cWC97bdRA5lSsdc710Vho9qzs6JPxK8MyrmaYAMBn6mvoWjBFLykGXrrZ0z7soA==",
+      "version": "2.11.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.11.0-alpha.1.tgz",
+      "integrity": "sha512-ywb6iUlq91q5AYbyBnMfyF/NW9oOK8P424GHmPsAgBFLhbkPP6EykmmkV1R06vXqftSNBaITR77ARijcdpDaZQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.10.1-alpha.1",
+    "@gisce/ooui": "2.11.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.6.0-alpha.14",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.11.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.11.0-alpha.1).