### PR TITLE
update gisce/react-formiga-table to v1.7.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.11.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.7.0-alpha.3",
+        "@gisce/react-formiga-table": "1.7.0-alpha.4",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.7.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0-alpha.3.tgz",
-      "integrity": "sha512-rwEWU0YMK4Tb4n7qvtwEca8c9kzWQjeBcN0TcZYkwRxQ2kSNKuDz5e2FocW9ns1dNkO9jvz21C9c1xcnydjGDw==",
+      "version": "1.7.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0-alpha.4.tgz",
+      "integrity": "sha512-t1WcAGbQeBn1h3hftO84BOyZBDlEJDoGIJnRRJKKRaQVVbmhmjTtMQpXGRXOb4VW9GK0q0MUIejBYGaDBkgt6g==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.11.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.7.0-alpha.3",
+    "@gisce/react-formiga-table": "1.7.0-alpha.4",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.7.0-alpha.4](https://github.com/gisce/react-formiga-table/releases/tag/v1.7.0-alpha.4).