### PR TITLE
update gisce/react-formiga-table to v1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.10.2",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.6.0",
+        "@gisce/react-formiga-table": "1.7.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "antd": "5.13.1",
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.6.0.tgz",
-      "integrity": "sha512-Q6LJxxSm0XA6NQWZJoXPbNdktgoFO9+xoSvPAvfJ5knJAfwM/0oGAwkx++Wbcn8LUyP3b51CfZ26VzJKEzxgwQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0.tgz",
+      "integrity": "sha512-UJMD5qBTgkJLzYGHKDjOT/eEY1ebt0QEx5xOqqFUVtEma9w50sVtLXvJEXAHfsQOBSvnm79jT9bOPzqGGHTSWA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "2.21.1",
+      "version": "2.21.2",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gisce/react-ooui",
-      "version": "2.21.0",
+      "version": "2.21.1",
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.10.2",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.6.0",
+    "@gisce/react-formiga-table": "1.7.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "antd": "5.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "engines": {
     "node": "20.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "engines": {
     "node": "20.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gisce/react-ooui",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "engines": {
     "node": "20.5.0"
   },

--- a/src/widgets/base/Selection.tsx
+++ b/src/widgets/base/Selection.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Select, theme } from "antd";
 import styled from "styled-components";
 
@@ -54,6 +53,7 @@ export const SelectionInput = (props: SelectionInputProps) => {
       onChange={onChange}
       value={value}
       optionFilterProp="children"
+      allowClear
       filterOption={(input: string, option: any) =>
         option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
       }

--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -133,6 +133,7 @@ const GraphIndicatorInput = (props: IndicatorInputProps) => {
           context={context}
           domain={domain}
           limit={limit}
+          fixedHeight
         />
       )}
     </GraphCard>

--- a/src/widgets/views/Graph/Graph.tsx
+++ b/src/widgets/views/Graph/Graph.tsx
@@ -30,10 +30,12 @@ export type GraphProps = {
   context: any;
   limit?: number;
   manualIds?: number[];
+  fixedHeight?: boolean;
 };
 
 const GraphComp = (props: GraphProps, ref: any) => {
-  const { view_id, model, context, domain, limit, manualIds } = props;
+  const { view_id, model, context, domain, limit, manualIds, fixedHeight } =
+    props;
   const [loading, setLoading] = useState(false);
   const [graphOoui, setGraphOoui] = useState<GraphOoui>();
   const actionViewContext = useContext(
@@ -120,6 +122,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
           ooui={graphOoui as GraphChartOoui}
           limit={limit}
           manualIds={manualIds}
+          fixedHeight={fixedHeight}
         />
       );
     }

--- a/src/widgets/views/Graph/GraphChart.tsx
+++ b/src/widgets/views/Graph/GraphChart.tsx
@@ -13,6 +13,7 @@ export type GraphChartProps = {
   ooui: GraphChartOoui;
   limit?: number;
   manualIds?: number[];
+  fixedHeight?: boolean;
 };
 
 export const GraphChart = ({
@@ -22,6 +23,7 @@ export const GraphChart = ({
   context,
   limit,
   manualIds,
+  fixedHeight,
 }: GraphChartProps) => {
   const { t } = useLocale();
 
@@ -58,6 +60,7 @@ export const GraphChart = ({
       isStack={isStack}
       numItems={evaluatedEntries!.length}
       yAxisOpts={yAxisOpts}
+      fixedHeight={fixedHeight}
     />
   );
 };

--- a/src/widgets/views/Graph/GraphChartComp.tsx
+++ b/src/widgets/views/Graph/GraphChartComp.tsx
@@ -10,6 +10,8 @@ import { GraphType, YAxisOpts } from "@gisce/ooui";
 
 const { Text } = Typography;
 
+const DEFAULT_HEIGHT = 400;
+
 const types = {
   line: Line,
   bar: Column,
@@ -23,6 +25,7 @@ export type GraphCompProps = {
   isStack: boolean;
   numItems: number;
   yAxisOpts?: YAxisOpts;
+  fixedHeight?: boolean;
 };
 
 export const GraphChartComp = ({
@@ -32,6 +35,7 @@ export const GraphChartComp = ({
   isStack,
   numItems,
   yAxisOpts,
+  fixedHeight = false,
 }: GraphCompProps) => {
   const { t } = useLocale();
 
@@ -105,6 +109,7 @@ export const GraphChartComp = ({
         flex: 1,
         padding: "1rem",
         gap: "10px",
+        height: fixedHeight ? DEFAULT_HEIGHT : undefined,
       }}
     >
       <div style={{ textAlign: "right" }}>
@@ -134,6 +139,7 @@ export const GraphChartComp = ({
             pieItemValueFormatter,
             pieLabelFormatter,
             yAxisOpts,
+            fixedHeight,
           })}
         />
       </div>
@@ -146,6 +152,7 @@ type GetGraphPropsType = GraphCompProps & {
   height?: number;
   pieItemValueFormatter?: any;
   pieLabelFormatter?: any;
+  fixedHeight?: boolean;
 };
 
 function getGraphProps(props: GetGraphPropsType) {
@@ -157,6 +164,7 @@ function getGraphProps(props: GetGraphPropsType) {
     pieItemValueFormatter,
     pieLabelFormatter,
     yAxisOpts = { mode: "default" },
+    fixedHeight = false,
   } = props;
   let graphProps = { ...(GraphDefaults as any)[type] };
 
@@ -165,6 +173,7 @@ function getGraphProps(props: GetGraphPropsType) {
   }
 
   graphProps.data = data;
+  graphProps.height = fixedHeight ? DEFAULT_HEIGHT : undefined;
 
   if (type === "pie") {
     graphProps.colorField = "x";

--- a/src/widgets/views/Graph/GraphServer.tsx
+++ b/src/widgets/views/Graph/GraphServer.tsx
@@ -20,10 +20,11 @@ export type GraphProps = {
   domain: any;
   context: any;
   manualIds?: number[];
+  fixedHeight?: boolean;
 };
 
 const GraphComp = (props: GraphProps, ref: any) => {
-  const { view_id, model, context, domain, manualIds } = props;
+  const { view_id, model, context, domain, manualIds, fixedHeight } = props;
   const actionViewContext = useContext(
     ActionViewContext,
   ) as ActionViewContextType;
@@ -91,6 +92,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
           isStack={chart.isStack}
           numItems={chart.num_items}
           yAxisOpts={chart.yAxisOpts}
+          fixedHeight={fixedHeight}
         />
       );
     }


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.7.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.7.0).