### PR TITLE
update gisce/react-formiga-table to v1.8.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.11.0",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.7.0",
+        "@gisce/react-formiga-table": "1.8.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,12 +3409,13 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0.tgz",
-      "integrity": "sha512-UJMD5qBTgkJLzYGHKDjOT/eEY1ebt0QEx5xOqqFUVtEma9w50sVtLXvJEXAHfsQOBSvnm79jT9bOPzqGGHTSWA==",
+      "version": "1.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.8.0-alpha.1.tgz",
+      "integrity": "sha512-4577hnExglzQwnHu2i/qPy2Njc9fxhAMj1MEOf/sFBJf2owyoTI1aSDT6hMv+/23kamj5pqwddAAvHpiZOjIdw==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",
+        "antd": "^5.13.1",
         "dequal": "^2.0.3",
         "lodash.debounce": "^4.0.8",
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.11.0",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.7.0",
+    "@gisce/react-formiga-table": "1.8.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.8.0-alpha.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.8.0-alpha.1).