### PR TITLE
update gisce/react-formiga-table to v1.8.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.11.0",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.8.0-alpha.3",
+        "@gisce/react-formiga-table": "1.8.0-alpha.4",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,15 +3409,15 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.8.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.8.0-alpha.3.tgz",
-      "integrity": "sha512-q4UE2sslFvtmKykL4JgXEttV7hcwbqgbeNwqQzP7Wjlx1oQk4OEeGKVPZxBOVQ+aTZPyXfh6yce7Xzi7mVshmQ==",
+      "version": "1.8.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.8.0-alpha.4.tgz",
+      "integrity": "sha512-FL8jxeTJsdq4wZ7pOrudMAm/5oQnPLBDiQwlKfrj7tezTfdfEU0nsiNyaFqbFJ7JW3lqnZ9YGhX4NlzTkW3szA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",
-        "antd": "^5.13.1",
         "dequal": "^2.0.3",
         "lodash.debounce": "^4.0.8",
+        "rc-dropdown": "^4.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "style-object-to-css-string": "^1.1.3",
@@ -3433,6 +3433,41 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5"
+      }
+    },
+    "node_modules/@gisce/react-formiga-table/node_modules/@rc-component/trigger": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.3.tgz",
+      "integrity": "sha512-X1oFIpKoXAMXNDYCviOmTfuNuYxE4h5laBsyCqVAVMjNHxoF3/uiyA7XdegK1XbCvBbCZ6P6byWrEoDRpKL8+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.38.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@gisce/react-formiga-table/node_modules/rc-dropdown": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
+      "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.11.0",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.8.0-alpha.3",
+    "@gisce/react-formiga-table": "1.8.0-alpha.4",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.8.0-alpha.4](https://github.com/gisce/react-formiga-table/releases/tag/v1.8.0-alpha.4).