### PR TITLE
update gisce/react-formiga-table to v1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.11.0",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.7.0",
+        "@gisce/react-formiga-table": "1.8.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,14 +3409,15 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.7.0.tgz",
-      "integrity": "sha512-UJMD5qBTgkJLzYGHKDjOT/eEY1ebt0QEx5xOqqFUVtEma9w50sVtLXvJEXAHfsQOBSvnm79jT9bOPzqGGHTSWA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.8.0.tgz",
+      "integrity": "sha512-ZbnuMZ7OpXGqw1AE7i7pidceRYjgYr1vdQqQRJrNPQe5sZBkUGsjW4ByanoEoM8xbY6hcAsdYZwxFLNH/bzjGQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",
         "dequal": "^2.0.3",
         "lodash.debounce": "^4.0.8",
+        "rc-dropdown": "^4.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "style-object-to-css-string": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.11.0",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.7.0",
+    "@gisce/react-formiga-table": "1.8.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.8.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.8.0).