### PR TITLE
update gisce/ooui to v2.12.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.11.0",
+        "@gisce/ooui": "2.12.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.11.0.tgz",
-      "integrity": "sha512-9BZ4p9/JIobkw//YcdBJ3v7sbCTPajeIeSvb3M8r2yDByImDuMvFWat5tzMYjmucRTJXs9v3qu9DW+2JDBTMsw==",
+      "version": "2.12.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.12.0-alpha.1.tgz",
+      "integrity": "sha512-MFLpX9asfIADNiHc6RfsrdikZgSOgLGr9B8vQ80YoN6Eap3AQ4e+5iIN23zMJZlZWllqksu4O43wc+kX3Jsb3w==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.11.0",
+    "@gisce/ooui": "2.12.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.12.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.12.0-alpha.1).