### PR TITLE
Allow use label widget on fields

### DIFF
--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Tooltip, Typography, theme } from "antd";
 import { WidgetProps } from "@/types";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { Label as LabelOoui } from "@gisce/ooui";
+import { FormContext, FormContextType } from "@/context/FormContext";
 import { Interweave } from "interweave";
 const { Text, Title } = Typography;
 const { useToken } = theme;
@@ -22,8 +23,12 @@ const Label = (props: Props) => {
   const { ooui, align, responsiveBehaviour } = props;
   const { label, tooltip, fieldForLabel, labelSize, labelType } =
     ooui as LabelOoui;
+  const formContext = useContext(FormContext) as FormContextType;
   const addColon = fieldForLabel !== null;
-  const labelText = addColon && label.length > 1 ? label + " :" : label;
+  let labelText = addColon && label.length > 1 ? label + " :" : label;
+  if (!ooui.fieldForLabel && ooui._id) {
+    labelText = formContext.getFieldValue(ooui._id);
+  }
   const responsiveAlign = responsiveBehaviour ? "left" : "right";
   const labelAlgin = align || (fieldForLabel ? responsiveAlign : "left");
   const { token } = useToken();

--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -9,6 +9,7 @@ const { Text, Title } = Typography;
 const { useToken } = theme;
 
 type Props = WidgetProps & {
+  ooui: LabelOoui;
   align?: "left" | "center" | "right";
   responsiveBehaviour?: boolean;
 };
@@ -21,8 +22,7 @@ const alignClass = {
 
 const Label = (props: Props) => {
   const { ooui, align, responsiveBehaviour } = props;
-  const { label, tooltip, fieldForLabel, labelSize, labelType } =
-    ooui as LabelOoui;
+  const { label, tooltip, fieldForLabel, labelSize, labelType } = ooui;
   const formContext = useContext(FormContext) as FormContextType;
   const addColon = fieldForLabel !== null;
   let labelText = addColon && label.length > 1 ? label + " :" : label;


### PR DESCRIPTION
Això ens permet fer servir widgets del tipus `label` per camps

Per exemple

```xml
<field name="name" select="1" colspan="4" widget="label"
       widget_props="{'label_size': 1, 'label_type': 'secondary'}"
/>
```

Ens dona

![image](https://github.com/user-attachments/assets/28c17584-71e4-4670-8af9-186c60e00831)
