### PR TITLE
update gisce/ooui to v2.13.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.12.0",
+        "@gisce/ooui": "2.13.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.12.0.tgz",
-      "integrity": "sha512-ndTsrp7MCv3T/ebfOcwgU30fg+YcnbVesMqGXtIcqeLjRUzUakXuvsk5fypH4pWvKuT6n6W1z+455Osc2fFUOg==",
+      "version": "2.13.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.13.0-alpha.1.tgz",
+      "integrity": "sha512-Yd9Vla4l/jSinW8xWz8axWIk8Xlul8htmyQnaxC5BSX5eq1qvzYK0cB2ueQwqEi6ouvsMHrqN9GFluKQxh/VDw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.12.0",
+    "@gisce/ooui": "2.13.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.13.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.13.0-alpha.1).