### PR TITLE
fix: trees without id don't load due to remote column state fetch behaviour

### DIFF
--- a/src/helpers/tree-columnStorageHelper.ts
+++ b/src/helpers/tree-columnStorageHelper.ts
@@ -4,8 +4,10 @@ export type TreeDataForHash = {
 };
 
 export const getKey = (dataForHash: TreeDataForHash) => {
-  if (!dataForHash.treeViewId || !dataForHash.model) {
+  if (!dataForHash.model) {
     return undefined;
   }
-  return `columnState-${dataForHash.treeViewId}-${dataForHash.model}`;
+
+  const treeViewIdPart = dataForHash.treeViewId ?? "tree";
+  return `columnState-${treeViewIdPart}-${dataForHash.model}`;
 };

--- a/src/widgets/base/one2many/useTreeColumnStorageFetch.ts
+++ b/src/widgets/base/one2many/useTreeColumnStorageFetch.ts
@@ -11,6 +11,7 @@ export const useTreeColumnStorageFetch = (key?: string) => {
 
   useEffect(() => {
     if (!key) {
+      setLoading(false);
       return;
     }
     const fetchColumnState = async () => {

--- a/src/widgets/views/SearchTreeInfinite.tsx
+++ b/src/widgets/views/SearchTreeInfinite.tsx
@@ -316,6 +316,7 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
       parentContext,
       setActionViewResults,
       setSearchQuery,
+      setTotalItemsActionView,
       treeOoui,
       treeView,
     ],


### PR DESCRIPTION
Fixes: https://github.com/gisce/webclient/issues/1284