### PR TITLE
update gisce/react-formiga-table to v1.9.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.12.1",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.8.1",
+        "@gisce/react-formiga-table": "1.9.0-alpha.2",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.8.1.tgz",
-      "integrity": "sha512-7rg2FeeiwXncG/17ERWu/N0I0pMvnCnixJty6FAtpvKbReC63A1KDN9Cjia6GwGPXDeNMBK1EWEe0HLpjyglqQ==",
+      "version": "1.9.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0-alpha.2.tgz",
+      "integrity": "sha512-IfJ5UihBwvPGSB5nV2fTi+UV50+aK1sinprtsHlE4eioIpkVj99t7cuh1Djnzi/D8cEjCg8syyuuCdwUmpOX/A==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.12.1",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.8.1",
+    "@gisce/react-formiga-table": "1.9.0-alpha.2",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.9.0-alpha.2](https://github.com/gisce/react-formiga-table/releases/tag/v1.9.0-alpha.2).