### PR TITLE
feat: add new arrowsteps widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import { Markdown } from "@/widgets/custom/Markdown";
 import { Radio } from "@/widgets/custom/Radio";
 import { Switch } from "@/widgets/custom/Switch";
 import { Steps } from "@/widgets/custom/Steps";
+import { ArrowStepsField } from "@/widgets/custom/ArrowSteps";
 import { CodeEditor } from "@/widgets/custom/CodeEditor";
 import { CommentsTimelineField } from "@/widgets/custom/Comments";
 import { HTMLPreview } from "@/widgets/custom/HTMLPreview";
@@ -162,6 +163,7 @@ export {
   Radio,
   Switch,
   Steps,
+  ArrowStepsField,
   CodeEditor,
   CommentsTimelineField,
   ExportModal,

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -29,6 +29,7 @@ import {
   Radio,
   Switch,
   Steps,
+  ArrowStepsField,
   Tag,
   CodeEditor,
   CommentsTimelineField,
@@ -118,6 +119,8 @@ const getWidgetType = (type: string) => {
       return Switch;
     case "steps":
       return Steps;
+    case "arrow_steps":
+      return ArrowStepsField;
     case "codeeditor":
       return CodeEditor;
     case "comments_timeline":

--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { theme } from "antd";
+import Field from "@/common/Field";
+import { WidgetProps } from "@/types";
+
+type ArrowStepsFieldProps = WidgetProps;
+
+type ArrowStepsProps = {
+  value?: Array<{ title: string; active: boolean }>;
+};
+
+export const ArrowSteps = (props: ArrowStepsProps) => {
+  const {
+    token: {
+      colorPrimaryBg,
+      colorPrimaryText,
+      colorFillSecondary,
+      colorBgContainer,
+      colorText,
+      fontFamily,
+      fontSize,
+    },
+  } = theme.useToken();
+
+  const progressStyle: React.CSSProperties = {
+    padding: 0,
+    listStyleType: "none",
+    fontFamily,
+    fontSize,
+    clear: "both",
+    lineHeight: "1em",
+    margin: "0 -1px",
+    textAlign: "center",
+    display: "flex",
+  };
+
+  const stepStyle = (isActive: boolean): React.CSSProperties => ({
+    position: "relative",
+    padding: "10px 30px 10px 40px",
+    backgroundColor: isActive ? colorPrimaryBg : colorFillSecondary,
+    color: isActive ? colorPrimaryText : colorText,
+    borderTop: `1px solid ${colorBgContainer}`,
+    borderBottom: `1px solid ${colorBgContainer}`,
+    width: "32%",
+    margin: "0 1px",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  });
+
+  const arrowBeforeStyle: React.CSSProperties = {
+    content: "''",
+    position: "absolute",
+    top: 0,
+    left: 0,
+    borderLeft: `16px solid ${colorBgContainer}`,
+    borderTop: "16px solid transparent",
+    borderBottom: "16px solid transparent",
+  };
+
+  const arrowAfterStyle = (isActive: boolean): React.CSSProperties => ({
+    content: "''",
+    position: "absolute",
+    top: 0,
+    left: "100%",
+    zIndex: 20,
+    borderLeft: `16px solid ${isActive ? colorPrimaryBg : colorFillSecondary}`,
+    borderTop: "16px solid transparent",
+    borderBottom: "16px solid transparent",
+  });
+
+  return (
+    <ul style={progressStyle}>
+      {(props.value || []).map((item, index) => (
+        <li key={index} style={stepStyle(item.active)}>
+          {item.title}
+          <div style={arrowBeforeStyle}></div>
+          <div style={arrowAfterStyle(item.active)}></div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export const ArrowStepsField = (props: ArrowStepsFieldProps) => {
+  return (
+    <Field {...props}>
+      <ArrowSteps />
+    </Field>
+  );
+};


### PR DESCRIPTION
Es pot fer servir fent servir el següent widget:

```xml
<field name="steps" widget="arrow_steps" nolabel="1" />
```

I de moment al costat del backend s'ha de fer un camp tipus `json` (normal o funció) que retorni la següent estructura.

```python
[
  {'title': 'Step 1', 'active': False},
  {'title': 'Step 2', 'active': True},
  {'title': 'Step 3', 'active': False}
]

```


![image](https://github.com/user-attachments/assets/bff6aa8c-ce28-41d1-98b8-4336d698c713)
