### PR TITLE
update gisce/ooui to v2.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.12.1",
+        "@gisce/ooui": "2.12.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.2",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.12.1.tgz",
-      "integrity": "sha512-AP//lc4CThN4ByWYHmL/zhGgWrfIJSGoATAubOB7vPSNHuDkzDNLGJo21tBSjECA7yDeQ5MrL8M6qA1JhN+QPg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.12.2.tgz",
+      "integrity": "sha512-ao5l1bdfdMVHzqIP1bm9QWfMZj8VdYSBbEziX3saTTJzhigHV3EEJ+pEB4iXCZlAFRtUwcyp4xy0iL1gzqbB/Q==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.12.1",
+    "@gisce/ooui": "2.12.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.12.2](https://github.com/gisce/ooui/releases/tag/v2.12.2).