### PR TITLE
update gisce/ooui to v2.13.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.12.2",
+        "@gisce/ooui": "2.13.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.2",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.12.2.tgz",
-      "integrity": "sha512-ao5l1bdfdMVHzqIP1bm9QWfMZj8VdYSBbEziX3saTTJzhigHV3EEJ+pEB4iXCZlAFRtUwcyp4xy0iL1gzqbB/Q==",
+      "version": "2.13.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.13.0-alpha.2.tgz",
+      "integrity": "sha512-2ykoKx9OZPX7wX+kgY+EKegmkS+kH6fhxZr1gGYBihY/pu5pvQzU5R3sOIss5wcaJ4FXmJ4SZ71oS7bjprZ37A==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.12.2",
+    "@gisce/ooui": "2.13.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.13.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.13.0-alpha.2).