### PR TITLE
feat(alert): allow action buttons inside alert widget

### DIFF
--- a/src/widgets/custom/Alert.tsx
+++ b/src/widgets/custom/Alert.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-import { Alert as AntdAlert } from "antd";
+import { Alert as AntdAlert, Space } from "antd";
 import { WidgetProps } from "@/types";
 import { Alert as AlertOoui } from "@gisce/ooui";
 import { Interweave } from "interweave";
 import iconMapper from "@/helpers/iconMapper";
+import { Button } from "@/widgets/base/Button";
 
-export const Alert = (props: WidgetProps) => {
+type AlertOouiProps = WidgetProps & {
+  ooui: AlertOoui;
+};
+
+export const Alert = (props: AlertOouiProps) => {
   const { ooui } = props;
-  const { title, text, alertType, icon } = ooui as AlertOoui;
+  const { title, text, alertType, icon } = ooui;
 
   function getIcon(icon: string | null): React.JSX.Element | undefined {
     if (icon) {
@@ -17,12 +22,17 @@ export const Alert = (props: WidgetProps) => {
     return undefined;
   }
 
+  const buttons = ooui.buttons.map((button) => {
+    return <Button ooui={button} />;
+  });
+
   return (
     <AntdAlert
       message={<Interweave content={title} />}
       description={<Interweave content={text} />}
       type={alertType}
       showIcon
+      action={buttons ? <Space direction="vertical">{buttons}</Space> : null}
       icon={getIcon(icon)}
     />
   );


### PR DESCRIPTION
```xml
<alert alert_type="info" title="Atención" text="Debes ir a la pestaña SIPS y pulsar el botón">
    <button type="object" string="Descarregar SIPS" icon="download" name="download_sips_ps_button"/>
</alert>
```

![image](https://github.com/user-attachments/assets/fee5c0e1-a151-448c-a4dd-10cab996b066)


Requires https://github.com/gisce/ooui/pull/126