### PR TITLE
update gisce/ooui to v2.14.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.14.0-alpha.1",
+        "@gisce/ooui": "2.14.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.3",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.14.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.14.0-alpha.1.tgz",
-      "integrity": "sha512-vmAC2nyeIv3nTg8O7/TXQMZz2/c7J544l1avJjGHhTOPgBSVVKQGiSPnkvR2itnj7smlEZRdbGaE2M+amkKdxA==",
+      "version": "2.14.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.14.0-alpha.2.tgz",
+      "integrity": "sha512-d0yA99QRe7jFKO26jGBaOPU9IloEJ8olZhJzTfqaInNNmSiEj74uIWxI6Njkkk/s49/OD0MfKijRgtCGsTQILA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.14.0-alpha.1",
+    "@gisce/ooui": "2.14.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.3",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.14.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.14.0-alpha.2).