### PR TITLE
feat: add icon on arrow steps

### DIFF
--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -70,7 +70,7 @@ export const ArrowSteps = (props: ArrowStepsProps) => {
     borderBottom: "16px solid transparent",
   });
 
-  const getIcon = (icon: string): React.Element => {
+  const getIcon = (icon: string): React.ElementType => {
     const Icon: React.ElementType = iconMapper(icon) as any;
     return Icon && <Icon />;
   };

--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { theme } from "antd";
+import { theme, Space } from "antd";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
+import iconMapper from "@/helpers/iconMapper";
 
 type ArrowStepsFieldProps = WidgetProps;
 
 type ArrowStepsProps = {
-  value?: Array<{ title: string; active: boolean }>;
+  value?: Array<{ title: string; active: boolean; icon?: string }>;
 };
 
 export const ArrowSteps = (props: ArrowStepsProps) => {
@@ -69,11 +70,18 @@ export const ArrowSteps = (props: ArrowStepsProps) => {
     borderBottom: "16px solid transparent",
   });
 
+  const getIcon = (icon: string): React.Element => {
+    const Icon: React.ElementType = iconMapper(icon) as any;
+    return Icon && <Icon />;
+  };
+
   return (
     <ul style={progressStyle}>
       {(props.value || []).map((item, index) => (
         <li key={index} style={stepStyle(item.active)}>
-          {item.title}
+          <Space>
+            {item.icon && getIcon(item.icon)} {item.title}
+          </Space>
           <div style={arrowBeforeStyle}></div>
           <div style={arrowAfterStyle(item.active)}></div>
         </li>

--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -70,7 +70,7 @@ export const ArrowSteps = (props: ArrowStepsProps) => {
     borderBottom: "16px solid transparent",
   });
 
-  const getIcon = (icon: string): React.ElementType => {
+  const getIcon = (icon: string): React.ReactElement => {
     const Icon: React.ElementType = iconMapper(icon) as any;
     return Icon && <Icon />;
   };


### PR DESCRIPTION
Afegir la possibilitat d'afegir icones davant dels texts dels arrow steps


```xml
<field name="steps" widget="arrow_steps" nolabel="1" />
```


En la part del backend en la descripció dels steps, s'ha d'afegir atribut  "icon" 

```python
       [
            {'title': _('Cancel·lada'), 'active': True},
            {'title': _('Esborrany'), 'active': False},
            {'title': _('Fitxer exportat'), 'active': False, 'icon': 'stop'},
            {'title': _('Pendent confirmació'), 'active': False, 'icon': 'stop'},
            {'title': _('Registrar sistema'), 'active': False, 'icon': 'stop'}
        ]

```
![image](https://github.com/user-attachments/assets/67953e2a-d3e0-4220-ab30-f9cb0bc0e793)


Origen PR: https://github.com/gisce/react-ooui/pull/631