### PR TITLE
update gisce/ooui to v2.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.13.1",
+        "@gisce/ooui": "2.13.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.3",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.13.1.tgz",
-      "integrity": "sha512-FwPznTE9SDlw+0Kj8qQdFx1Ib6jn/oJkCPzYmijvbQHH6QUjXHEnb1CmfOfq9tfZ6k0C85yM+avIBtCO5+j7sw==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.13.2.tgz",
+      "integrity": "sha512-GQgHANcpSnegI2/kv1qBq7FLpe/P95pDwPUcxj02/52dz1fbthqT5JbTrNbE6BwZNbRNoZKlnaRGI1EL/Ick3A==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.13.1",
+    "@gisce/ooui": "2.13.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.3",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.13.2](https://github.com/gisce/ooui/releases/tag/v2.13.2).