### PR TITLE
feat(Tag): allow use tag in boolean fields

### DIFF
--- a/src/helpers/formHelper.ts
+++ b/src/helpers/formHelper.ts
@@ -251,7 +251,11 @@ export const transformPlainMany2Ones = ({
   return reformattedValues;
 };
 
-export const colorFromString = (text: string) => {
+export const colorFromBoolean = (value: boolean): string => {
+  return value ? "success" : "error";
+};
+
+export const colorFromString = (text: string): string => {
   let hash = 0;
   text = text.toString().padEnd(10, "0");
   for (let i = 0; i < text.length; i++) {

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -106,4 +106,5 @@ export default {
   filter: "Filtrar",
   applyFilters: "Aplicar filtres",
   resetTableView: "Restablir vista de taula",
+  not: "No",
 };

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -102,4 +102,5 @@ export default {
   filter: "Filter",
   applyFilters: "Apply filters",
   resetTableView: "Reset table view",
+  not: "Not",
 };

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -108,4 +108,5 @@ export default {
   filter: "Filtrar",
   applyFilters: "Aplicar filtros",
   resetTableView: "Restablecer vista de tabla",
+  not: "No",
 };

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -3,7 +3,13 @@ import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { Tag as AntdTag, TagProps } from "antd";
 import { isPresetStatusColor, isPresetColor } from "antd/lib/_util/colors";
-import { colorFromString } from "@/helpers/formHelper";
+import { colorFromString, colorFromBoolean } from "@/helpers/formHelper";
+import { useLocale } from "@gisce/react-formiga-components";
+
+function capitalizeFirstLetter(text: string): string {
+  if (text.length === 0) return text;
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
 
 export const Tag = (props: WidgetProps) => {
   return (
@@ -14,22 +20,30 @@ export const Tag = (props: WidgetProps) => {
 };
 
 export const TagInput = (props: any) => {
+  const { t } = useLocale();
   const { ooui, value } = props;
   let formattedValue = value;
+  let colorMethod: any = colorFromString;
   let colorValue = value;
   if (ooui.selectionValues.size) {
     formattedValue = ooui.selectionValues.get(value);
   } else if (Array.isArray(value)) {
     colorValue = value[0];
     formattedValue = value[1];
+  } else if (ooui.fieldType === "boolean") {
+    formattedValue = value
+      ? capitalizeFirstLetter(ooui.label)
+      : `${t("not")} ${ooui.label.toLowerCase()}`;
+    colorMethod = colorFromBoolean;
   }
-  if (!value) {
+
+  if (!formattedValue) {
     return null;
   }
   const color =
     ooui.colors === "auto"
-      ? colorFromString(colorValue)
-      : ooui.colors[colorValue] || colorFromString(colorValue);
+      ? colorMethod(colorValue)
+      : ooui.colors[colorValue] || colorMethod(colorValue);
   return <CustomTag color={color}>{formattedValue}</CustomTag>;
 };
 


### PR DESCRIPTION
Permet utilitzar el widget `tag` en els camps boleans.

- El contingut serà el del **label** i afegirà el prefix "No" davant si està a `false`
  - Si volem personalitzar el contingut només per una vista podem fer servir l'atribut `string` del tag `<field />`
- Per defecte farà que `true` sigui verd i `false` vermell
  - Es poden personalitzar els colors amb el `widget_props` igual que els altres:

```xml
<field name="customer" widget="tag" widget_props="{'colors': {'true': 'blue', 'false': 'magenta'}}"/>
<field name="supplier" widget="tag" widget_props="{'colors': {'true': 'blue', 'false': 'magenta'}}"/>
```

![image](https://github.com/user-attachments/assets/3f688a33-ba99-47fe-9a23-193899b94c13)


## Dependencies

- https://github.com/gisce/ooui/pull/132
- Closes https://github.com/gisce/webclient/issues/1359
