### PR TITLE
update gisce/ooui to v2.15.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.14.0",
+        "@gisce/ooui": "2.15.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.4",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.14.0.tgz",
-      "integrity": "sha512-K+2hSzuyvHJspW6DMTHrz5TENribGnUcQxOGVgipqkUoAW4AkPGd7CUYSc9xdN62YmRF7sQ7sNJrd2rLZSPFwg==",
+      "version": "2.15.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.15.0-alpha.1.tgz",
+      "integrity": "sha512-rotbTwryiYcWX7VIOrHDAEa9owUbYVYVcJ2p5NjpCFs3wl9TcYq7z/x9eWjOR6GbluL84KRAwFxxOO2FpJb5og==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.14.0",
+    "@gisce/ooui": "2.15.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.4",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.15.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.15.0-alpha.1).