### PR TITLE
update gisce/ooui to v2.16.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.15.0-alpha.2",
+        "@gisce/ooui": "2.16.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.4",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.15.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.15.0-alpha.2.tgz",
-      "integrity": "sha512-ZL89NFgeuFFKXQjyiK4B6Wpi7AxPVyAqPbYvhxywicBsPyojh9/ZIc32N3fbyEti3uZK/kTINJ5tem4zQBmd4w==",
+      "version": "2.16.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.16.0-alpha.1.tgz",
+      "integrity": "sha512-NpAvuNSQtvpQ76QnyQ6eFG7zMjbvLsy4rJFKDg1onvN2X6mvy/dO+OywzedGf1bg4A+e0oWKG0ZlFAaTXr8Wfg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.15.0-alpha.2",
+    "@gisce/ooui": "2.16.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.4",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.16.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.16.0-alpha.1).