### PR TITLE
update gisce/ooui to v2.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.16.0",
+        "@gisce/ooui": "2.16.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.4",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.16.0.tgz",
-      "integrity": "sha512-ahDLiEQfhvbYJd4FsP90qpp/ZZEWco3dqrqNxt5CdJYRBz8qHmiXryhaKa1SgUXCl1LpueZ4ZQPxPb4Ylat9sw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.16.1.tgz",
+      "integrity": "sha512-ZZ7xMtY2DZvCOVQ+K6ytJgv55IKKTR1TPqnel09dxtzAOmFupCDUj+K+X7BEYlOwRFyo3WUE5/bGljewcT0+tg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.16.0",
+    "@gisce/ooui": "2.16.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.4",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.16.1](https://github.com/gisce/ooui/releases/tag/v2.16.1).