### PR TITLE
update gisce/ooui to v2.17.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.16.1",
+        "@gisce/ooui": "2.17.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.16.1.tgz",
-      "integrity": "sha512-ZZ7xMtY2DZvCOVQ+K6ytJgv55IKKTR1TPqnel09dxtzAOmFupCDUj+K+X7BEYlOwRFyo3WUE5/bGljewcT0+tg==",
+      "version": "2.17.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.17.0-alpha.2.tgz",
+      "integrity": "sha512-MNZFzesL9YLX3Ez6NFtjyk1QmmUtoLe3ijNVMvlCw93BGyR5kVW7/mOeXHjyJDaMu6HYjYpf5peNb/O4JH4jkA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.16.1",
+    "@gisce/ooui": "2.17.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.17.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.17.0-alpha.2).