### PR TITLE
update gisce/ooui to v2.18.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.18.0-alpha.2",
+        "@gisce/ooui": "2.18.0-alpha.3",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.5",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.18.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.18.0-alpha.2.tgz",
-      "integrity": "sha512-aIQDXvjGEPUoGhXmXNn/M1Jbz4DARwOp3ZdQj5g2WQCGQZTG3Kg9Pj0eh4fe3ImarE8z4TR6s16Ft26hYzUyfw==",
+      "version": "2.18.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.18.0-alpha.3.tgz",
+      "integrity": "sha512-Jq2wxABTNOPVLhl6WfudmjowAriBwdKjT41+PVjVdCA1vCRR7ivOrsa8Xz5isUIK68UqLR6YHC29JHQOgBjUew==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.18.0-alpha.2",
+    "@gisce/ooui": "2.18.0-alpha.3",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.5",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.18.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.18.0-alpha.3).