### PR TITLE
update gisce/ooui to v2.18.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.18.0",
+        "@gisce/ooui": "2.18.0-alpha.4",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.7",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.18.0.tgz",
-      "integrity": "sha512-f5bHBjruxJQ+Xb77RvQgp22TfeTz5HeL45MO4+Jl32UdWzCkAtzxSAwA/INPPaTCrvhE5N14HpS2PdCdBLqhBA==",
+      "version": "2.18.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.18.0-alpha.4.tgz",
+      "integrity": "sha512-rqSV2n3BxVSgw8jP9izc0UaL7XlfQB6jTqNn7C0QYzVVNlPWJi0k1BMIDRet938ol1K7onQovAOQnFnyeOfQeg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.18.0",
+    "@gisce/ooui": "2.18.0-alpha.4",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.7",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.18.0-alpha.4](https://github.com/gisce/ooui/releases/tag/v2.18.0-alpha.4).