### PR TITLE
update gisce/react-formiga-table to v1.9.0-alpha.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.18.0-alpha.4",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.9.0-alpha.7",
+        "@gisce/react-formiga-table": "1.9.0-alpha.8",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.9.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0-alpha.7.tgz",
-      "integrity": "sha512-hLGomcr//6MwlVKkJbpWoxSzGebl1CcTKHFztX/RXDniEEBxLDsL+Loug4qyid5P4pGQECssWruhR221EzKNHg==",
+      "version": "1.9.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0-alpha.8.tgz",
+      "integrity": "sha512-8PH6J0lnqBaskYHAFpl7vlvpEHqnooC78Zpb0pXNqa2KEH5MPgU/GBbruU8lg+KFfouCDq/6KEYg3hBifPcu8A==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.18.0-alpha.4",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.9.0-alpha.7",
+    "@gisce/react-formiga-table": "1.9.0-alpha.8",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.9.0-alpha.8](https://github.com/gisce/react-formiga-table/releases/tag/v1.9.0-alpha.8).