### PR TITLE
update gisce/ooui to v2.18.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.19.0",
+        "@gisce/ooui": "2.18.0-alpha.5",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.8",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.19.0.tgz",
-      "integrity": "sha512-zG5Ta8I/sBCiKpjfs05rPo8z/9mhuHvG4qiaZiqIxvtcTAdi7HY9a6hEJLKx4wfexisR+bl8/uxiSiDmc/YiQw==",
+      "version": "2.18.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.18.0-alpha.5.tgz",
+      "integrity": "sha512-YtTr9Th/3wYk21ZVTtUG/M1prK6nh4MrmDJBVJMv/LO4C5r4C7D/TAfIc8cT72liHNtobZ75qreFOx5/u7yCpg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.19.0",
+    "@gisce/ooui": "2.18.0-alpha.5",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.8",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.18.0-alpha.5](https://github.com/gisce/ooui/releases/tag/v2.18.0-alpha.5).