### PR TITLE
update gisce/ooui to v2.21.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.20.0",
+        "@gisce/ooui": "2.21.0-alpha.1",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.8",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.20.0.tgz",
-      "integrity": "sha512-IeoZ55dM7vwVebUtLm2oxSCbGbKwxEYCjl7PO6ZAlpjvtWyXy7dVHLo+fT/90gnAO1XlT6sCRCORJhtbGy5d9A==",
+      "version": "2.21.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0-alpha.1.tgz",
+      "integrity": "sha512-fWPPkY8DsHeb+QvOQU2dYSIy6Bb63H9nbL33vAnyBwpk//sIrdHwKuGiANlEeaIS5mAAWi3eDqN+66A3nEgryQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.20.0",
+    "@gisce/ooui": "2.21.0-alpha.1",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.8",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.21.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.21.0-alpha.1).