### PR TITLE
update gisce/ooui to v2.21.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.21.0-alpha.1",
+        "@gisce/ooui": "2.21.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.9",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.21.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0-alpha.1.tgz",
-      "integrity": "sha512-fWPPkY8DsHeb+QvOQU2dYSIy6Bb63H9nbL33vAnyBwpk//sIrdHwKuGiANlEeaIS5mAAWi3eDqN+66A3nEgryQ==",
+      "version": "2.21.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0-alpha.2.tgz",
+      "integrity": "sha512-gl0Pyb6HRypsYxeT3Girjcw+vxEMVRmZcDnzeqxqbVhkxq9soAEwo2kW9YM4lJN65XMqU9e2K/J8E1Blf+i9zg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.21.0-alpha.1",
+    "@gisce/ooui": "2.21.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.9",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.21.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.21.0-alpha.2).