### PR TITLE
Allow use Groups and Pages as Spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.20.0",
+        "@gisce/ooui": "2.21.0",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.5",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.20.0.tgz",
-      "integrity": "sha512-IeoZ55dM7vwVebUtLm2oxSCbGbKwxEYCjl7PO6ZAlpjvtWyXy7dVHLo+fT/90gnAO1XlT6sCRCORJhtbGy5d9A==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0.tgz",
+      "integrity": "sha512-ft6G/o2hUb74BQPpDRomZIJ28B625INSFFYUECGHKJwy0C00RwnKvA4jX7lodtxdMrAtARneKeihPoy5bRSsnQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.20.0",
+    "@gisce/ooui": "2.21.0",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.5",
     "@monaco-editor/react": "^4.4.5",

--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -107,4 +107,5 @@ export default {
   applyFilters: "Aplicar filtres",
   resetTableView: "Restablir vista de taula",
   not: "No",
+  loading: "Carregant...",
 };

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -103,4 +103,5 @@ export default {
   applyFilters: "Apply filters",
   resetTableView: "Reset table view",
   not: "Not",
+  loading: "Loading...",
 };

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -109,4 +109,5 @@ export default {
   applyFilters: "Aplicar filtros",
   resetTableView: "Restablecer vista de tabla",
   not: "No",
+  loading: "Cargando...",
 };

--- a/src/widgets/containers/Group.tsx
+++ b/src/widgets/containers/Group.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Group as GroupOoui } from "@gisce/ooui";
-import Container from "./Container";
-import { FieldSet } from "@gisce/react-formiga-components";
-import { Space } from "antd";
+import { Spinner } from "@/widgets/custom/Spinner";
+import { FieldSet , useLocale } from "@gisce/react-formiga-components";
 import iconMapper from "@/helpers/iconMapper";
 
 type Props = {
@@ -14,19 +13,21 @@ type Props = {
 function Group(props: Props): React.ReactElement {
   const { ooui, showLabel = true, responsiveBehaviour } = props;
   const icon: React.ElementType | undefined = iconMapper(ooui.icon || "");
-
+  const { t } = useLocale();
   return (
     <>
       {(ooui.label || icon) && showLabel ? (
         <FieldSet label={ooui.label} icon={icon}>
-          <Container
-            container={ooui!.container}
+          <Spinner
+            tip={t("loading")}
+            ooui={ooui}
             responsiveBehaviour={responsiveBehaviour}
           />
         </FieldSet>
       ) : (
-        <Container
-          container={ooui!.container}
+        <Spinner
+          tip={t("loading")}
+          ooui={ooui}
           responsiveBehaviour={responsiveBehaviour}
         />
       )}

--- a/src/widgets/custom/Spinner.tsx
+++ b/src/widgets/custom/Spinner.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import { WidgetProps } from "@/types";
 import { Spinner as SpinnerOoui } from "@gisce/ooui";
 import { Spin } from "antd";
 import Container from "@/widgets/containers/Container";
 
-type SpinnerProps = WidgetProps & {
+type SpinnerProps = Omit<WidgetProps, "ooui"> & {
   ooui: SpinnerOoui;
   responsiveBehaviour?: boolean;
   tip?: string;

--- a/src/widgets/custom/Spinner.tsx
+++ b/src/widgets/custom/Spinner.tsx
@@ -6,14 +6,19 @@ import Container from "@/widgets/containers/Container";
 
 type SpinnerProps = WidgetProps & {
   ooui: SpinnerOoui;
+  responsiveBehaviour?: boolean;
+  tip?: string;
 };
 
 export const Spinner = (props: SpinnerProps) => {
-  const { ooui } = props;
+  const { ooui, responsiveBehaviour = false, tip } = props;
 
   return (
-    <Spin tip={ooui.label} size="large" spinning={ooui.loading}>
-      <Container container={ooui.container} responsiveBehaviour={false} />
+    <Spin tip={tip ?? ooui.label} size="large" spinning={ooui.loading}>
+      <Container
+        container={ooui.container}
+        responsiveBehaviour={responsiveBehaviour}
+      />
     </Spin>
   );
 };


### PR DESCRIPTION
This pull request includes changes to add a loading message translation in multiple locales and to replace the `Container` component with a new `Spinner` component in the `Group` widget. The most important changes are summarized below:

### Localization Updates:
* Added a translation for the loading message in `src/locales/ca_ES.ts`
* Added a translation for the loading message in `src/locales/en_US.ts`
* Added a translation for the loading message in `src/locales/es_ES.ts`

### Component Updates:
* Updated `src/widgets/containers/Group.tsx` to replace the `Container` component with the `Spinner` component and utilize the `useLocale` hook for localized loading messages [[1]](diffhunk://#diff-b1fcab73136e9bd79dbe9d523271c98426a90e64aea2e063b333b264178558faL3-R4) [[2]](diffhunk://#diff-b1fcab73136e9bd79dbe9d523271c98426a90e64aea2e063b333b264178558faL17-R30)
* Modified `src/widgets/custom/Spinner.tsx` to accept additional props for `responsiveBehaviour` and `tip`, and adjusted the component to use these props

### Dependencies
- Needs https://github.com/gisce/ooui/pull/146