### PR TITLE
Alert: allow to use widget dynamically for a field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.21.0",
+        "@gisce/ooui": "2.22.0",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.5",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0.tgz",
-      "integrity": "sha512-ft6G/o2hUb74BQPpDRomZIJ28B625INSFFYUECGHKJwy0C00RwnKvA4jX7lodtxdMrAtARneKeihPoy5bRSsnQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.22.0.tgz",
+      "integrity": "sha512-q7ZUY7hMBQtTo+E+SJ3blVnsSdYKf7oMPn+ppwWXLLXoZBZEWI52qkNXO6ukGl3l6YjftujmE0AFN3U4sICpgg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.21.0",
+    "@gisce/ooui": "2.22.0",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.5",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/custom/Alert.tsx
+++ b/src/widgets/custom/Alert.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Alert as AntdAlert, Space } from "antd";
 import { WidgetProps } from "@/types";
-import { Alert as AlertOoui } from "@gisce/ooui";
+import { Alert as AlertOoui, Button as ButtonOoui } from "@gisce/ooui";
 import { Interweave } from "interweave";
 import iconMapper from "@/helpers/iconMapper";
 import { Button } from "@/widgets/base/Button";
+import { FormContext, FormContextType } from "@/context/FormContext";
 
 type AlertOouiProps = WidgetProps & {
   ooui: AlertOoui;
@@ -12,7 +13,21 @@ type AlertOouiProps = WidgetProps & {
 
 export const Alert = (props: AlertOouiProps) => {
   const { ooui } = props;
-  const { title, text, alertType, icon } = ooui;
+  const formContext = useContext(FormContext) as FormContextType;
+  let { title, text, alertType, icon } = ooui;
+  if (ooui.fieldType && ooui.id) {
+    const values = formContext.getFieldValue(ooui.id);
+    if (typeof values === "object") {
+      ({
+        title = ooui.title,
+        text = ooui.text,
+        alertType = ooui.alertType,
+        icon = ooui.icon,
+      } = values);
+    } else {
+      console.log(`field value for ${ooui.id} is not an object`);
+    }
+  }
 
   function getIcon(icon: string | null): React.JSX.Element | undefined {
     if (icon) {
@@ -22,8 +37,8 @@ export const Alert = (props: AlertOouiProps) => {
     return undefined;
   }
 
-  const buttons = ooui.buttons.map((button) => {
-    return <Button ooui={button} />;
+  const buttons = ooui.buttons.map((button: ButtonOoui) => {
+    return <Button key={button.id} ooui={button} />;
   });
 
   return (

--- a/src/widgets/custom/Alert.tsx
+++ b/src/widgets/custom/Alert.tsx
@@ -14,7 +14,7 @@ type AlertOouiProps = WidgetProps & {
 export const Alert = (props: AlertOouiProps) => {
   const { ooui } = props;
   const formContext = useContext(FormContext) as FormContextType;
-  let { title, text, alertType, icon } = ooui;
+  let { title, text, alertType, icon, buttons } = ooui;
   if (ooui.fieldType && ooui.id) {
     const values = formContext.getFieldValue(ooui.id);
     if (typeof values === "object") {
@@ -23,7 +23,17 @@ export const Alert = (props: AlertOouiProps) => {
         text = ooui.text,
         alertType = ooui.alertType,
         icon = ooui.icon,
+        buttons = [],
       } = values);
+      if (buttons) {
+        buttons = buttons.map(
+          (button: any) =>
+            new ButtonOoui({ ...button, ...{ readonly: ooui.readOnly } }),
+        );
+      }
+      if (ooui.buttons) {
+        buttons = [...ooui.buttons, ...buttons];
+      }
     } else {
       console.log(`field value for ${ooui.id} is not an object`);
     }
@@ -37,7 +47,7 @@ export const Alert = (props: AlertOouiProps) => {
     return undefined;
   }
 
-  const buttons = ooui.buttons.map((button: ButtonOoui) => {
+  const buttonsComponents = buttons.map((button: ButtonOoui) => {
     return <Button key={button.id} ooui={button} />;
   });
 
@@ -47,7 +57,11 @@ export const Alert = (props: AlertOouiProps) => {
       description={<Interweave content={text} />}
       type={alertType}
       showIcon
-      action={buttons ? <Space direction="vertical">{buttons}</Space> : null}
+      action={
+        buttonsComponents ? (
+          <Space direction="vertical">{buttonsComponents}</Space>
+        ) : null
+      }
       icon={getIcon(icon)}
     />
   );


### PR DESCRIPTION
This pull request includes enhancements to the `Alert` component in the `src/widgets/custom/Alert.tsx` file. The changes primarily focus on integrating form context and improving the handling of alert properties and buttons.

Enhancements to `Alert` component:

* Added `useContext` to import `FormContext` and `FormContextType` for accessing form values.
* Modified the `Alert` component to dynamically update its properties (`title`, `text`, `alertType`, `icon`) based on form field values if available.
* Improved the rendering of buttons within the `Alert` component by adding a `key` prop to each button to ensure unique identification.

## Dependencies
- https://github.com/gisce/ooui/pull/149