### PR TITLE
update gisce/ooui to v2.21.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.21.0-alpha.3",
+        "@gisce/ooui": "2.21.0-alpha.4",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.9",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.21.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0-alpha.3.tgz",
-      "integrity": "sha512-67P6NjRVAqRUuOXCgS2xnkgwjRJL9NIlWtRefOoRyebkhwrHgGr5wjCCJBzmCiWf5LH2y+7EXlGMKr+N7rTlbg==",
+      "version": "2.21.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.21.0-alpha.4.tgz",
+      "integrity": "sha512-Hk485hHgouFqsWRG669zDLyMYIyLbrJsJWlrW12lLnJ+0tdeMgnv+ODTcpXBvRQoHGIlY9IcxJwXJm++b7IRxw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.21.0-alpha.3",
+    "@gisce/ooui": "2.21.0-alpha.4",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.9",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.21.0-alpha.4](https://github.com/gisce/ooui/releases/tag/v2.21.0-alpha.4).