### PR TITLE
update gisce/react-formiga-table to v1.9.0-alpha.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.21.0-alpha.4",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.9.0-alpha.9",
+        "@gisce/react-formiga-table": "1.9.0-alpha.10",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.9.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0-alpha.9.tgz",
-      "integrity": "sha512-5/EnpAgmFnkZ2pFSz0JV+xeazzsVVnRTPe05Omlnc2RbqMFwXRK4bDopGSN0z8Iz51LSOYX+Ek40YR5mMXCn9g==",
+      "version": "1.9.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0-alpha.10.tgz",
+      "integrity": "sha512-EgyNasuGqeezRLiR3orqIgvfj42jEqJJikiXVQSZH4Fym6YNgdUY25iKC4QOtk2X07eyF0T8TERhTMqXWifHmA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.21.0-alpha.4",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.9.0-alpha.9",
+    "@gisce/react-formiga-table": "1.9.0-alpha.10",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.9.0-alpha.10](https://github.com/gisce/react-formiga-table/releases/tag/v1.9.0-alpha.10).