### PR TITLE
feat(Field): allow suffix and prefix

### DIFF
--- a/src/common/AddonElement.tsx
+++ b/src/common/AddonElement.tsx
@@ -1,0 +1,9 @@
+import { memo } from "react";
+import { theme } from "antd";
+const { useToken } = theme;
+
+export const AddonElement = memo(({ content }: { content: string }) => {
+  const { token } = useToken();
+  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
+});
+AddonElement.displayName = "AddonElement";

--- a/src/widgets/base/Char.tsx
+++ b/src/widgets/base/Char.tsx
@@ -63,6 +63,7 @@ const CharInput = ({
   const { elementHasLostFocus } = formContext || {};
   const { id, readOnly, isPassword, translatable } = ooui;
   const showCount = ooui.size !== undefined && ooui.showCount;
+  const { token } = useToken();
 
   if (ooui.selectionValues.size) {
     value = ooui.selectionValues.get(value);
@@ -72,6 +73,16 @@ const CharInput = ({
 
   let input = (
     <Input
+      addonBefore={
+        ooui.prefix ? (
+          <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
+        ) : null
+      }
+      addonAfter={
+        ooui.suffix ? (
+          <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
+        ) : null
+      }
       value={value}
       disabled={readOnly || (translatable && !isSearchField)}
       id={id}

--- a/src/widgets/base/Char.tsx
+++ b/src/widgets/base/Char.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties, useContext, useState } from "react";
-import { Checkbox as AntCheckbox, Col, Input, Row, theme } from "antd";
+import { useContext, useState } from "react";
+import { Col, Input, Row, theme } from "antd";
 import Field from "@/common/Field";
 import { Char as CharOoui } from "@gisce/ooui";
 import { WidgetProps } from "@/types";
@@ -24,24 +24,11 @@ type CharProps = WidgetProps & {
 export const Char = (props: CharProps) => {
   const { ooui, isSearchField = false } = props;
   const { id, readOnly, required, translatable } = ooui as CharOoui;
-  const { token } = useToken();
-  const requiredStyle =
-    required && !readOnly
-      ? { backgroundColor: token.colorPrimaryBg }
-      : undefined;
 
-  let input = (
-    <CharInput
-      ooui={ooui}
-      requiredStyle={requiredStyle}
-      isSearchField={isSearchField}
-    />
-  );
+  let input = <CharInput ooui={ooui} isSearchField={isSearchField} />;
 
   if (translatable && !readOnly && !isSearchField) {
-    input = (
-      <TranslatableChar ooui={ooui} field={id} requiredStyle={requiredStyle} />
-    );
+    input = <TranslatableCharComp ooui={ooui} field={id} />;
   }
 
   return (
@@ -54,13 +41,11 @@ export const Char = (props: CharProps) => {
 const CharInput = ({
   value,
   ooui,
-  requiredStyle,
   isSearchField,
   onChange,
 }: {
   value?: any;
   ooui: CharOoui;
-  requiredStyle: CSSProperties | undefined;
   isSearchField: boolean;
   onChange?: (value: string) => void;
 }) => {
@@ -71,6 +56,7 @@ const CharInput = ({
   const { id, readOnly, isPassword, translatable, required } = ooui;
   const showCount = ooui.size !== undefined && ooui.showCount;
   const { token } = useToken();
+  const isRequired = required && !readOnly;
 
   if (ooui.selectionValues.size) {
     value = ooui.selectionValues.get(value);
@@ -78,7 +64,7 @@ const CharInput = ({
     value = value[1];
   }
 
-  const Component = required ? RequiredChar : Input;
+  const Component = isRequired ? RequiredChar : Input;
 
   let input = (
     <Component
@@ -105,7 +91,7 @@ const CharInput = ({
   );
 
   if (isPassword) {
-    const PasswordComponent = isPassword ? RequiredPassword : Input.Password;
+    const PasswordComponent = isRequired ? RequiredPassword : Input.Password;
     input = (
       <PasswordComponent
         addonBefore={
@@ -131,7 +117,7 @@ const CharInput = ({
 
   if (forceDisabled) {
     input = (
-      <Input
+      <Component
         value={value}
         id={id}
         disabled
@@ -152,17 +138,15 @@ const CharInput = ({
   return input;
 };
 
-const TranslatableChar = ({
+const TranslatableCharComp = ({
   ooui,
   value,
   field,
-  requiredStyle,
   onChange,
 }: {
   ooui: CharOoui;
   value?: string;
   field: string;
-  requiredStyle: CSSProperties | undefined;
   onChange?: (value: string) => void;
 }) => {
   const formContext = useContext(FormContext) as FormContextType;
@@ -175,55 +159,58 @@ const TranslatableChar = ({
   } = formContext || {};
   const [translationModalVisible, setTranslationModalVisible] = useState(false);
   const { t } = useLocale();
+  const { token } = useToken();
+  const { required, readOnly } = ooui;
+  const isRequired = required && !readOnly;
 
   if (!activeId) {
+    const Component = isRequired ? RequiredChar : Input;
     return (
-      <>
-        <Row gutter={8} wrap={false}>
-          <Col flex="auto">
-            <Input
-              addonBefore={
-                ooui.prefix ? (
-                  <div style={{ color: token.colorTextDisabled }}>
-                    {ooui.prefix}
-                  </div>
-                ) : null
+      <Row gutter={8} wrap={false}>
+        <Col flex="auto">
+          <Component
+            addonBefore={
+              ooui.prefix ? (
+                <div style={{ color: token.colorTextDisabled }}>
+                  {ooui.prefix}
+                </div>
+              ) : null
+            }
+            addonAfter={
+              ooui.suffix ? (
+                <div style={{ color: token.colorTextDisabled }}>
+                  {ooui.suffix}
+                </div>
+              ) : null
+            }
+            value={value}
+            id={field}
+            onChange={(event: any) => {
+              onChange?.(event.target.value);
+            }}
+            onBlur={elementHasLostFocus}
+          />
+        </Col>
+        <Col flex="none">
+          <ButtonWithTooltip
+            tooltip={t("translate")}
+            icon={<TranslationOutlined />}
+            onClick={async () => {
+              if (formHasChanges?.()) {
+                showInfo(t("saveBeforeTranslate"));
+              } else {
+                showInfo(t("enterTextBeforeTranslate"));
               }
-              addonAfter={
-                ooui.suffix ? (
-                  <div style={{ color: token.colorTextDisabled }}>
-                    {ooui.suffix}
-                  </div>
-                ) : null
-              }
-              value={value}
-              id={field}
-              style={requiredStyle}
-              onChange={(event: any) => {
-                onChange?.(event.target.value);
-              }}
-              onBlur={elementHasLostFocus}
-            />
-          </Col>
-          <Col flex="none">
-            <ButtonWithTooltip
-              tooltip={t("translate")}
-              icon={<TranslationOutlined />}
-              onClick={async () => {
-                if (formHasChanges?.()) {
-                  showInfo(t("saveBeforeTranslate"));
-                } else {
-                  showInfo(t("enterTextBeforeTranslate"));
-                }
-              }}
-            >
-              {t("translate")}
-            </ButtonWithTooltip>
-          </Col>
-        </Row>
-      </>
+            }}
+          >
+            {t("translate")}
+          </ButtonWithTooltip>
+        </Col>
+      </Row>
     );
   }
+
+  const Component = isRequired ? RequiredTranslatableChar : TranslatableChar;
 
   return (
     <>
@@ -239,7 +226,7 @@ const TranslatableChar = ({
           }
         }}
       >
-        <Input
+        <Component
           value={value}
           disabled={true}
           id={field}
@@ -247,7 +234,6 @@ const TranslatableChar = ({
             onChange?.(event.target.value);
           }}
           onBlur={elementHasLostFocus}
-          style={{ cursor: "pointer", pointerEvents: "none", ...requiredStyle }}
         />
       </div>
       <TranslationModal
@@ -266,6 +252,21 @@ const TranslatableChar = ({
     </>
   );
 };
+
+const TranslatableChar = styled(Input)`
+  .ant-input {
+    cursor: pointer;
+    pointer-events: none;
+  }
+`;
+
+const RequiredTranslatableChar = styled(Input)`
+  .ant-input {
+    background-color: ${mapToken.colorPrimaryBg};
+    cursor: pointer;
+    pointer-events: none;
+  }
+`;
 
 const RequiredChar = styled(Input)`
   .ant-input {

--- a/src/widgets/base/Char.tsx
+++ b/src/widgets/base/Char.tsx
@@ -10,7 +10,7 @@ import { TranslationOutlined } from "@ant-design/icons";
 import { useLocale } from "@gisce/react-formiga-components";
 import showInfo from "@/ui/InfoDialog";
 import styled from "styled-components";
-const { useToken } = theme;
+import { AddonElement } from "@/common/AddonElement";
 
 const { defaultAlgorithm, defaultSeed } = theme;
 
@@ -20,12 +20,6 @@ type CharProps = WidgetProps & {
   ooui: CharOoui;
   isSearchField?: boolean;
 };
-
-const AddonElement = memo(({ content }: { content: string }) => {
-  const { token } = useToken();
-  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
-});
-AddonElement.displayName = "AddonElement";
 
 interface BaseInputProps {
   component: React.ComponentType<any>;

--- a/src/widgets/base/Char.tsx
+++ b/src/widgets/base/Char.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, memo, useCallback, useMemo } from "react";
 import { Col, Input, Row, theme } from "antd";
 import Field from "@/common/Field";
 import { Char as CharOoui } from "@gisce/ooui";
@@ -21,6 +21,52 @@ type CharProps = WidgetProps & {
   isSearchField?: boolean;
 };
 
+const AddonElement = memo(({ content }: { content: string }) => {
+  const { token } = useToken();
+  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
+});
+AddonElement.displayName = "AddonElement";
+
+interface BaseInputProps {
+  component: React.ComponentType<any>;
+  ooui: CharOoui;
+  value: string | undefined;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
+  disabled?: boolean;
+  [key: string]: any;
+}
+
+const BaseInput = memo(
+  ({
+    component: Component,
+    ooui,
+    value,
+    onChange,
+    onBlur,
+    disabled,
+    ...props
+  }: BaseInputProps) => {
+    const renderAddonElement = useCallback((content?: string) => {
+      return content ? <AddonElement content={content} /> : null;
+    }, []);
+
+    return (
+      <Component
+        addonBefore={renderAddonElement(ooui.prefix)}
+        addonAfter={renderAddonElement(ooui.suffix)}
+        value={value}
+        disabled={disabled}
+        id={ooui.id}
+        onBlur={onBlur}
+        onChange={onChange}
+        {...props}
+      />
+    );
+  },
+);
+BaseInput.displayName = "BaseInput";
+
 export const Char = (props: CharProps) => {
   const { ooui, isSearchField = false } = props;
   const { id, readOnly, required, translatable } = ooui as CharOoui;
@@ -38,230 +84,201 @@ export const Char = (props: CharProps) => {
   );
 };
 
-const CharInput = ({
-  value,
-  ooui,
-  isSearchField,
-  onChange,
-}: {
-  value?: any;
-  ooui: CharOoui;
-  isSearchField: boolean;
-  onChange?: (value: string) => void;
-}) => {
-  const forceDisabled =
-    Array.isArray(value) || Boolean(ooui.selectionValues.size);
-  const formContext = useContext(FormContext) as FormContextType;
-  const { elementHasLostFocus } = formContext || {};
-  const { id, readOnly, isPassword, translatable, required } = ooui;
-  const showCount = ooui.size !== undefined && ooui.showCount;
-  const { token } = useToken();
-  const isRequired = required && !readOnly;
+const CharInput = memo(
+  ({
+    value,
+    ooui,
+    isSearchField,
+    onChange,
+  }: {
+    value?: any;
+    ooui: CharOoui;
+    isSearchField: boolean;
+    onChange?: (value: string) => void;
+  }) => {
+    const formContext = useContext(FormContext) as FormContextType;
+    const { elementHasLostFocus } = formContext || {};
+    const { readOnly, isPassword, translatable, required } = ooui;
 
-  if (ooui.selectionValues.size) {
-    value = ooui.selectionValues.get(value);
-  } else if (Array.isArray(value)) {
-    value = value[1];
-  }
-
-  const Component = isRequired ? RequiredChar : Input;
-
-  let input = (
-    <Component
-      addonBefore={
-        ooui.prefix ? (
-          <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
-        ) : null
+    const computedValue = useMemo(() => {
+      if (!value) return value;
+      if (ooui.selectionValues.size) {
+        return ooui.selectionValues.get(value);
       }
-      addonAfter={
-        ooui.suffix ? (
-          <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
-        ) : null
-      }
-      value={value}
-      disabled={readOnly || (translatable && !isSearchField)}
-      id={id}
-      showCount={showCount}
-      maxLength={ooui.size}
-      onBlur={elementHasLostFocus}
-      onChange={(event: any) => {
+      return Array.isArray(value) ? value[1] : value;
+    }, [ooui.selectionValues, value]);
+
+    const isRequired = useMemo(
+      () => required && !readOnly,
+      [required, readOnly],
+    );
+    if (ooui._id === "name") {
+      console.log({ value });
+    }
+    console.log({ isRequired });
+
+    const forceDisabled = useMemo(
+      () => Array.isArray(value) || Boolean(ooui.selectionValues.size),
+      [value, ooui.selectionValues],
+    );
+
+    const handleChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
         onChange?.(event.target.value);
-      }}
-    />
-  );
-
-  if (isPassword) {
-    const PasswordComponent = isRequired ? RequiredPassword : Input.Password;
-    input = (
-      <PasswordComponent
-        addonBefore={
-          ooui.prefix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
-          ) : null
-        }
-        addonAfter={
-          ooui.suffix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
-          ) : null
-        }
-        value={value}
-        disabled={readOnly}
-        id={id}
-        onBlur={elementHasLostFocus}
-        onChange={(event: any) => {
-          onChange?.(event.target.value);
-        }}
-      />
+      },
+      [onChange],
     );
-  }
 
-  if (forceDisabled) {
-    input = (
-      <Component
-        value={value}
-        id={id}
-        disabled
-        addonBefore={
-          ooui.prefix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
-          ) : null
-        }
-        addonAfter={
-          ooui.suffix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
-          ) : null
-        }
-      />
-    );
-  }
+    if (isPassword) {
+      const PasswordComponent = isRequired ? RequiredPassword : Input.Password;
+      return (
+        <BaseInput
+          component={PasswordComponent}
+          ooui={ooui}
+          value={computedValue}
+          disabled={readOnly}
+          onBlur={elementHasLostFocus}
+          onChange={handleChange}
+        />
+      );
+    }
 
-  return input;
-};
-
-const TranslatableCharComp = ({
-  ooui,
-  value,
-  field,
-  onChange,
-}: {
-  ooui: CharOoui;
-  value?: string;
-  field: string;
-  onChange?: (value: string) => void;
-}) => {
-  const formContext = useContext(FormContext) as FormContextType;
-  const {
-    activeId,
-    activeModel,
-    fetchValues,
-    formHasChanges,
-    elementHasLostFocus,
-  } = formContext || {};
-  const [translationModalVisible, setTranslationModalVisible] = useState(false);
-  const { t } = useLocale();
-  const { token } = useToken();
-  const { required, readOnly } = ooui;
-  const isRequired = required && !readOnly;
-
-  if (!activeId) {
     const Component = isRequired ? RequiredChar : Input;
     return (
-      <Row gutter={8} wrap={false}>
-        <Col flex="auto">
-          <Component
-            addonBefore={
-              ooui.prefix ? (
-                <div style={{ color: token.colorTextDisabled }}>
-                  {ooui.prefix}
-                </div>
-              ) : null
-            }
-            addonAfter={
-              ooui.suffix ? (
-                <div style={{ color: token.colorTextDisabled }}>
-                  {ooui.suffix}
-                </div>
-              ) : null
-            }
+      <BaseInput
+        component={Component}
+        ooui={ooui}
+        value={computedValue}
+        disabled={readOnly || forceDisabled || (translatable && !isSearchField)}
+        showCount={ooui.size !== undefined && ooui.showCount}
+        maxLength={ooui.size}
+        onBlur={elementHasLostFocus}
+        onChange={handleChange}
+      />
+    );
+  },
+);
+CharInput.displayName = "CharInput";
+
+const TranslatableCharComp = memo(
+  ({
+    ooui,
+    value,
+    field,
+    onChange,
+  }: {
+    ooui: CharOoui;
+    value?: string;
+    field: string;
+    onChange?: (value: string) => void;
+  }) => {
+    const formContext = useContext(FormContext) as FormContextType;
+    const {
+      activeId,
+      activeModel,
+      fetchValues,
+      formHasChanges,
+      elementHasLostFocus,
+    } = formContext || {};
+    const [translationModalVisible, setTranslationModalVisible] =
+      useState(false);
+    const { t } = useLocale();
+    const { required, readOnly } = ooui;
+
+    const isRequired = useMemo(
+      () => required && !readOnly,
+      [required, readOnly],
+    );
+
+    const handleChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange?.(event.target.value);
+      },
+      [onChange],
+    );
+
+    const handleTranslationClick = useCallback(() => {
+      if (formHasChanges?.()) {
+        showInfo(t("saveBeforeTranslate"));
+        return;
+      }
+      setTranslationModalVisible(true);
+    }, [formHasChanges, t]);
+
+    const handleModalClose = useCallback(() => {
+      setTranslationModalVisible(false);
+    }, []);
+
+    const handleModalSubmit = useCallback(() => {
+      setTranslationModalVisible(false);
+      fetchValues?.();
+    }, [fetchValues]);
+
+    const Component = isRequired ? RequiredTranslatableChar : TranslatableChar;
+
+    if (!activeId) {
+      const NonActiveComponent = isRequired ? RequiredChar : Input;
+      return (
+        <Row gutter={8} wrap={false}>
+          <Col flex="auto">
+            <BaseInput
+              component={NonActiveComponent}
+              ooui={ooui}
+              value={value}
+              id={field}
+              onChange={handleChange}
+              onBlur={elementHasLostFocus}
+            />
+          </Col>
+          <Col flex="none">
+            <ButtonWithTooltip
+              tooltip={t("translate")}
+              icon={<TranslationOutlined />}
+              onClick={handleTranslationClick}
+            >
+              {t("translate")}
+            </ButtonWithTooltip>
+          </Col>
+        </Row>
+      );
+    }
+
+    return (
+      <>
+        <div onClick={handleTranslationClick}>
+          <BaseInput
+            component={Component}
+            ooui={ooui}
             value={value}
+            disabled={true}
             id={field}
-            onChange={(event: any) => {
-              onChange?.(event.target.value);
-            }}
+            onChange={handleChange}
             onBlur={elementHasLostFocus}
           />
-        </Col>
-        <Col flex="none">
-          <ButtonWithTooltip
-            tooltip={t("translate")}
-            icon={<TranslationOutlined />}
-            onClick={async () => {
-              if (formHasChanges?.()) {
-                showInfo(t("saveBeforeTranslate"));
-              } else {
-                showInfo(t("enterTextBeforeTranslate"));
-              }
-            }}
-          >
-            {t("translate")}
-          </ButtonWithTooltip>
-        </Col>
-      </Row>
-    );
-  }
-
-  const Component = isRequired ? RequiredTranslatableChar : TranslatableChar;
-
-  return (
-    <>
-      <div
-        onClick={() => {
-          if (formHasChanges?.()) {
-            showInfo(t("saveBeforeTranslate"));
-            return;
-          }
-
-          if (!translationModalVisible) {
-            setTranslationModalVisible(true);
-          }
-        }}
-      >
-        <Component
-          value={value}
-          disabled={true}
-          id={field}
-          onChange={(event: any) => {
-            onChange?.(event.target.value);
-          }}
-          onBlur={elementHasLostFocus}
+        </div>
+        <TranslationModal
+          id={activeId}
+          model={activeModel}
+          field={field}
+          visible={translationModalVisible}
+          onCloseModal={handleModalClose}
+          onSubmitSucceed={handleModalSubmit}
         />
-      </div>
-      <TranslationModal
-        id={activeId!}
-        model={activeModel}
-        field={field}
-        visible={translationModalVisible}
-        onCloseModal={() => {
-          setTranslationModalVisible(false);
-        }}
-        onSubmitSucceed={() => {
-          setTranslationModalVisible(false);
-          fetchValues?.();
-        }}
-      />
-    </>
-  );
-};
+      </>
+    );
+  },
+);
+TranslatableCharComp.displayName = "TranslatableCharComp";
 
-const TranslatableChar = styled(Input)`
-  .ant-input {
-    cursor: pointer;
-    pointer-events: none;
+const TranslatableChar = styled(Input)<{ disabled?: boolean }>`
+  &.ant-input {
+    cursor: ${(props) => (props.disabled ? "pointer" : "text")};
+    pointer-events: ${(props) => (props.disabled ? "none" : "auto")};
   }
 `;
 
 const RequiredTranslatableChar = styled(Input)`
-  .ant-input {
+  &.ant-input {
     background-color: ${mapToken.colorPrimaryBg};
     cursor: pointer;
     pointer-events: none;
@@ -269,13 +286,13 @@ const RequiredTranslatableChar = styled(Input)`
 `;
 
 const RequiredChar = styled(Input)`
-  .ant-input {
+  &.ant-input {
     background-color: ${mapToken.colorPrimaryBg};
   }
 `;
 
 const RequiredPassword = styled(Input.Password)`
-  .ant-input {
+  &.ant-input-affix-wrapper {
     background-color: ${mapToken.colorPrimaryBg};
   }
 `;

--- a/src/widgets/base/Char.tsx
+++ b/src/widgets/base/Char.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useContext, useState } from "react";
-import { Col, Input, Row, theme } from "antd";
+import { Checkbox as AntCheckbox, Col, Input, Row, theme } from "antd";
 import Field from "@/common/Field";
 import { Char as CharOoui } from "@gisce/ooui";
 import { WidgetProps } from "@/types";
@@ -9,7 +9,12 @@ import ButtonWithTooltip from "@/common/ButtonWithTooltip";
 import { TranslationOutlined } from "@ant-design/icons";
 import { useLocale } from "@gisce/react-formiga-components";
 import showInfo from "@/ui/InfoDialog";
+import styled from "styled-components";
 const { useToken } = theme;
+
+const { defaultAlgorithm, defaultSeed } = theme;
+
+const mapToken = defaultAlgorithm(defaultSeed);
 
 type CharProps = WidgetProps & {
   ooui: CharOoui;
@@ -34,7 +39,9 @@ export const Char = (props: CharProps) => {
   );
 
   if (translatable && !readOnly && !isSearchField) {
-    input = <TranslatableChar field={id} requiredStyle={requiredStyle} />;
+    input = (
+      <TranslatableChar ooui={ooui} field={id} requiredStyle={requiredStyle} />
+    );
   }
 
   return (
@@ -61,7 +68,7 @@ const CharInput = ({
     Array.isArray(value) || Boolean(ooui.selectionValues.size);
   const formContext = useContext(FormContext) as FormContextType;
   const { elementHasLostFocus } = formContext || {};
-  const { id, readOnly, isPassword, translatable } = ooui;
+  const { id, readOnly, isPassword, translatable, required } = ooui;
   const showCount = ooui.size !== undefined && ooui.showCount;
   const { token } = useToken();
 
@@ -71,8 +78,10 @@ const CharInput = ({
     value = value[1];
   }
 
+  const Component = required ? RequiredChar : Input;
+
   let input = (
-    <Input
+    <Component
       addonBefore={
         ooui.prefix ? (
           <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
@@ -87,7 +96,6 @@ const CharInput = ({
       disabled={readOnly || (translatable && !isSearchField)}
       id={id}
       showCount={showCount}
-      style={requiredStyle}
       maxLength={ooui.size}
       onBlur={elementHasLostFocus}
       onChange={(event: any) => {
@@ -97,8 +105,19 @@ const CharInput = ({
   );
 
   if (isPassword) {
+    const PasswordComponent = isPassword ? RequiredPassword : Input.Password;
     input = (
-      <Input.Password
+      <PasswordComponent
+        addonBefore={
+          ooui.prefix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
+          ) : null
+        }
+        addonAfter={
+          ooui.suffix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
+          ) : null
+        }
         value={value}
         disabled={readOnly}
         id={id}
@@ -111,18 +130,36 @@ const CharInput = ({
   }
 
   if (forceDisabled) {
-    input = <Input value={value} id={id} disabled />;
+    input = (
+      <Input
+        value={value}
+        id={id}
+        disabled
+        addonBefore={
+          ooui.prefix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
+          ) : null
+        }
+        addonAfter={
+          ooui.suffix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
+          ) : null
+        }
+      />
+    );
   }
 
   return input;
 };
 
 const TranslatableChar = ({
+  ooui,
   value,
   field,
   requiredStyle,
   onChange,
 }: {
+  ooui: CharOoui;
   value?: string;
   field: string;
   requiredStyle: CSSProperties | undefined;
@@ -145,6 +182,20 @@ const TranslatableChar = ({
         <Row gutter={8} wrap={false}>
           <Col flex="auto">
             <Input
+              addonBefore={
+                ooui.prefix ? (
+                  <div style={{ color: token.colorTextDisabled }}>
+                    {ooui.prefix}
+                  </div>
+                ) : null
+              }
+              addonAfter={
+                ooui.suffix ? (
+                  <div style={{ color: token.colorTextDisabled }}>
+                    {ooui.suffix}
+                  </div>
+                ) : null
+              }
               value={value}
               id={field}
               style={requiredStyle}
@@ -215,3 +266,15 @@ const TranslatableChar = ({
     </>
   );
 };
+
+const RequiredChar = styled(Input)`
+  .ant-input {
+    background-color: ${mapToken.colorPrimaryBg};
+  }
+`;
+
+const RequiredPassword = styled(Input.Password)`
+  .ant-input {
+    background-color: ${mapToken.colorPrimaryBg};
+  }
+`;

--- a/src/widgets/base/Float.tsx
+++ b/src/widgets/base/Float.tsx
@@ -1,49 +1,65 @@
-import React, { useContext } from "react";
-import { InputNumber, theme } from "antd";
+import { memo, useCallback, useContext, useMemo } from "react";
+import { InputNumber, InputNumberProps, theme } from "antd";
 import Field from "@/common/Field";
 import { Float as FloatOoui } from "@gisce/ooui";
 import { WidgetProps } from "@/types";
 
 import { FormContext, FormContextType } from "@/context/FormContext";
+import styled from "styled-components";
 const { useToken } = theme;
 
-export const Float = (props: WidgetProps) => {
+const { defaultAlgorithm, defaultSeed } = theme;
+
+const mapToken = defaultAlgorithm(defaultSeed);
+
+const AddonElement = memo(({ content }: { content: string }) => {
+  const { token } = useToken();
+  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
+});
+AddonElement.displayName = "AddonElement";
+
+export const Float = memo((props: WidgetProps) => {
   const { ooui } = props;
   const { id, decimalDigits, readOnly, required } = ooui as FloatOoui;
-  const { token } = useToken();
 
-  const requiredStyle =
-    required && !readOnly
-      ? { backgroundColor: token.colorPrimaryBg }
-      : undefined;
-  const formContext = useContext(FormContext) as FormContextType;
-  const { elementHasLostFocus } = formContext || {};
+  const { elementHasLostFocus } = useContext(FormContext) as FormContextType;
+
+  const isRequired = useMemo(() => required && !readOnly, [required, readOnly]);
+
+  const Component: React.ComponentType<InputNumberProps> = useMemo(
+    () => (isRequired ? RequiredFloat : InputNumber),
+    [isRequired],
+  );
+
+  const renderAddonElement = useCallback((content?: string) => {
+    return content ? <AddonElement content={content} /> : null;
+  }, []);
+
+  const formatter = useCallback((value: any) => {
+    return `${value}`.replace(/[^0-9.-]+/g, "");
+  }, []);
 
   return (
-    <Field required={required} type={"number"} {...props}>
-      <InputNumber
-        addonBefore={
-          ooui.prefix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
-          ) : null
-        }
-        addonAfter={
-          ooui.suffix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
-          ) : null
-        }
+    <Field required={isRequired} type="number" {...props}>
+      <Component
+        addonBefore={renderAddonElement(ooui.prefix)}
+        addonAfter={renderAddonElement(ooui.suffix)}
         disabled={readOnly}
-        className={"w-full"}
-        style={requiredStyle}
+        className="w-full"
         id={id}
         precision={decimalDigits}
-        formatter={(value) => {
-          return `${value}`.replace(/[^0-9.-]+/g, "");
-        }}
-        decimalSeparator={"."}
+        formatter={formatter}
+        decimalSeparator="."
         onBlur={elementHasLostFocus}
         wheel={false}
       />
     </Field>
   );
-};
+});
+Float.displayName = "Float";
+
+const RequiredFloat = styled(InputNumber)`
+  &.ant-input-number {
+    background-color: ${mapToken.colorPrimaryBg};
+  }
+`;

--- a/src/widgets/base/Float.tsx
+++ b/src/widgets/base/Float.tsx
@@ -22,8 +22,9 @@ export const Float = memo((props: WidgetProps) => {
   const { ooui } = props;
   const { id, decimalDigits, readOnly, required } = ooui as FloatOoui;
 
-  const { elementHasLostFocus } = useContext(FormContext) as FormContextType;
+  const formContext = useContext(FormContext) as FormContextType;
 
+  const { elementHasLostFocus } = formContext || {};
   const isRequired = useMemo(() => required && !readOnly, [required, readOnly]);
 
   const Component: React.ComponentType<InputNumberProps> = useMemo(

--- a/src/widgets/base/Float.tsx
+++ b/src/widgets/base/Float.tsx
@@ -22,6 +22,16 @@ export const Float = (props: WidgetProps) => {
   return (
     <Field required={required} type={"number"} {...props}>
       <InputNumber
+        addonBefore={
+          ooui.prefix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
+          ) : null
+        }
+        addonAfter={
+          ooui.suffix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
+          ) : null
+        }
         disabled={readOnly}
         className={"w-full"}
         style={requiredStyle}

--- a/src/widgets/base/Float.tsx
+++ b/src/widgets/base/Float.tsx
@@ -6,17 +6,11 @@ import { WidgetProps } from "@/types";
 
 import { FormContext, FormContextType } from "@/context/FormContext";
 import styled from "styled-components";
-const { useToken } = theme;
+import { AddonElement } from "@/common/AddonElement";
 
 const { defaultAlgorithm, defaultSeed } = theme;
 
 const mapToken = defaultAlgorithm(defaultSeed);
-
-const AddonElement = memo(({ content }: { content: string }) => {
-  const { token } = useToken();
-  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
-});
-AddonElement.displayName = "AddonElement";
 
 export const Float = memo((props: WidgetProps) => {
   const { ooui } = props;

--- a/src/widgets/base/Integer.tsx
+++ b/src/widgets/base/Integer.tsx
@@ -4,6 +4,7 @@ import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { FormContext, FormContextType } from "@/context/FormContext";
 import styled from "styled-components";
+import { AddonElement } from "@/common/AddonElement";
 const { useToken } = theme;
 
 const { defaultAlgorithm, defaultSeed } = theme;
@@ -13,12 +14,6 @@ const mapToken = defaultAlgorithm(defaultSeed);
 type IntegerProps = WidgetProps & {
   onChange?: (newValue: number) => void;
 };
-
-const AddonElement = memo(({ content }: { content: string }) => {
-  const { token } = useToken();
-  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
-});
-AddonElement.displayName = "AddonElement";
 
 export const Integer = memo((props: IntegerProps) => {
   const { ooui, onChange } = props;

--- a/src/widgets/base/Integer.tsx
+++ b/src/widgets/base/Integer.tsx
@@ -1,15 +1,26 @@
-import React, { useContext } from "react";
-import { InputNumber, theme } from "antd";
+import { memo, useCallback, useContext, useMemo } from "react";
+import { InputNumber, InputNumberProps, theme } from "antd";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { FormContext, FormContextType } from "@/context/FormContext";
+import styled from "styled-components";
 const { useToken } = theme;
+
+const { defaultAlgorithm, defaultSeed } = theme;
+
+const mapToken = defaultAlgorithm(defaultSeed);
 
 type IntegerProps = WidgetProps & {
   onChange?: (newValue: number) => void;
 };
 
-export const Integer = (props: IntegerProps) => {
+const AddonElement = memo(({ content }: { content: string }) => {
+  const { token } = useToken();
+  return <div style={{ color: token.colorTextDisabled }}>{content}</div>;
+});
+AddonElement.displayName = "AddonElement";
+
+export const Integer = memo((props: IntegerProps) => {
   const { ooui, onChange } = props;
   const { id, readOnly, required } = ooui;
   const { token } = useToken();
@@ -18,44 +29,54 @@ export const Integer = (props: IntegerProps) => {
       ? { backgroundColor: token.colorPrimaryBg }
       : undefined;
   const formContext = useContext(FormContext) as FormContextType;
+
   const { elementHasLostFocus } = formContext || {};
+  const isRequired = useMemo(() => required && !readOnly, [required, readOnly]);
+
+  const Component: React.ComponentType<InputNumberProps> = useMemo(
+    () => (isRequired ? RequiredInteger : InputNumber),
+    [isRequired],
+  );
+
+  const renderAddonElement = useCallback((content?: string) => {
+    return content ? <AddonElement content={content} /> : null;
+  }, []);
+
+  const formatter = useCallback((value: any) => {
+    // Check if value is not undefined and is a valid number
+    if (value === undefined) {
+      return "";
+    }
+
+    if (typeof value === "string" && !isNaN(parseFloat(value))) {
+      const truncatedValue = Math.trunc(parseFloat(value));
+      return `${truncatedValue}`.replace(/[^0-9\-]+/g, "");
+    } else if (typeof value === "number") {
+      const truncatedValue = Math.trunc(value);
+      return `${truncatedValue}`.replace(/[^0-9\-]+/g, "");
+    }
+
+    return "";
+  }, []);
+
+  const handleChange = useCallback(
+    (newValue: any) => {
+      const newNumber = newValue as number;
+      onChange?.(newNumber);
+    },
+    [onChange],
+  );
 
   return (
-    <Field required={required} type={"number"} {...props}>
-      <InputNumber
-        addonBefore={
-          ooui.prefix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
-          ) : null
-        }
-        addonAfter={
-          ooui.suffix ? (
-            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
-          ) : null
-        }
+    <Field required={isRequired} type={"number"} {...props}>
+      <Component
+        addonBefore={renderAddonElement(ooui.prefix)}
+        addonAfter={renderAddonElement(ooui.suffix)}
         id={id}
         className={"w-full "}
         disabled={readOnly}
-        formatter={(value) => {
-          // Check if value is not undefined and is a valid number
-          if (value === undefined) {
-            return "";
-          }
-
-          if (typeof value === "string" && !isNaN(parseFloat(value))) {
-            const truncatedValue = Math.trunc(parseFloat(value));
-            return `${truncatedValue}`.replace(/[^0-9\-]+/g, "");
-          } else if (typeof value === "number") {
-            const truncatedValue = Math.trunc(value);
-            return `${truncatedValue}`.replace(/[^0-9\-]+/g, "");
-          }
-
-          return "";
-        }}
-        onChange={(newValue: any) => {
-          const newNumber = newValue as number;
-          onChange?.(newNumber);
-        }}
+        formatter={formatter}
+        onChange={handleChange}
         onBlur={elementHasLostFocus}
         precision={0}
         style={requiredStyle}
@@ -63,4 +84,11 @@ export const Integer = (props: IntegerProps) => {
       />
     </Field>
   );
-};
+});
+Integer.displayName = "Integer";
+
+const RequiredInteger = styled(InputNumber)`
+  &.ant-input-number {
+    background-color: ${mapToken.colorPrimaryBg};
+  }
+`;

--- a/src/widgets/base/Integer.tsx
+++ b/src/widgets/base/Integer.tsx
@@ -23,6 +23,16 @@ export const Integer = (props: IntegerProps) => {
   return (
     <Field required={required} type={"number"} {...props}>
       <InputNumber
+        addonBefore={
+          ooui.prefix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.prefix}</div>
+          ) : null
+        }
+        addonAfter={
+          ooui.suffix ? (
+            <div style={{ color: token.colorTextDisabled }}>{ooui.suffix}</div>
+          ) : null
+        }
         id={id}
         className={"w-full "}
         disabled={readOnly}


### PR DESCRIPTION
This pull request includes enhancements to the `Char`, `Float`, and `Integer` input components in the `src/widgets/base` directory. The changes mainly focus on adding support for prefixes and suffixes to these input fields.

Enhancements to input components:

* [`src/widgets/base/Char.tsx`](diffhunk://#diff-784e53d34ff3d9528825c0800ce673757f996417494fa8ed6efa2a5ca100d631R66): Added support for `prefix` and `suffix` properties to the `CharInput` component, displaying them with a disabled text color. [[1]](diffhunk://#diff-784e53d34ff3d9528825c0800ce673757f996417494fa8ed6efa2a5ca100d631R66) [[2]](diffhunk://#diff-784e53d34ff3d9528825c0800ce673757f996417494fa8ed6efa2a5ca100d631R76-R85)
* [`src/widgets/base/Float.tsx`](diffhunk://#diff-a94031808d20337255c35aa2051b189d38f107dbbe19b0281837cdf3a39bf620R25-R34): Added support for `prefix` and `suffix` properties to the `Float` component, displaying them with a disabled text color.
* [`src/widgets/base/Integer.tsx`](diffhunk://#diff-be8d77b254280c6f0beee06b869217662c90d90355423eb93c19e09c627d3f59R26-R35): Added support for `prefix` and `suffix` properties to the `Integer` component, displaying them with a disabled text color.

- Depends on https://github.com/gisce/ooui/pull/152
- Closes https://github.com/gisce/webclient/issues/1501