### PR TITLE
update gisce/ooui to v2.23.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.22.0",
+        "@gisce/ooui": "2.23.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0-alpha.10",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.22.0.tgz",
-      "integrity": "sha512-q7ZUY7hMBQtTo+E+SJ3blVnsSdYKf7oMPn+ppwWXLLXoZBZEWI52qkNXO6ukGl3l6YjftujmE0AFN3U4sICpgg==",
+      "version": "2.23.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.23.0-alpha.2.tgz",
+      "integrity": "sha512-zstauAcCJrDgq4VkbVdluYYV4XNSg9R8OP4u6od9ZSgvh/C7LHkycLTNr/ZSyV2BDBqwk2zRnYaDkVEFjswy3A==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.22.0",
+    "@gisce/ooui": "2.23.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0-alpha.10",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.23.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.23.0-alpha.2).