### PR TITLE
Add carousel widget

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import { Alert } from "@/widgets/custom/Alert";
 import { DashboardGrid } from "@/widgets/views/DashboardGrid";
 import { GraphIndicator } from "@/widgets/views/Graph/GraphIndicator";
 import { Spinner } from "@/widgets/custom/Spinner";
+import { Carousel } from "@/widgets/custom/Carousel";
 
 import type {
   TreeView,
@@ -179,4 +180,5 @@ export {
   Alert,
   dayjs,
   Spinner,
+  Carousel,
 };

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -36,6 +36,7 @@ import {
   HTMLPreview,
   Alert,
   Spinner,
+  Carousel,
 } from "@/index";
 import { Image } from "./base/Image";
 import { FiberGrid } from "./custom/FiberGrid";
@@ -133,6 +134,8 @@ const getWidgetType = (type: string) => {
       return Alert;
     case "spinner":
       return Spinner;
+    case "carousel":
+      return Carousel;
     default:
       return undefined;
   }

--- a/src/widgets/custom/Carousel.tsx
+++ b/src/widgets/custom/Carousel.tsx
@@ -1,0 +1,42 @@
+import { WidgetProps } from "@/types";
+import { Carousel as CarouselOoui, Group as GroupOoui } from "@gisce/ooui";
+import { Carousel as AntCarousel, theme } from "antd";
+import Container from "@/widgets/containers/Container";
+import styled from "styled-components";
+
+const { defaultAlgorithm, defaultSeed } = theme;
+
+const mapToken = defaultAlgorithm(defaultSeed);
+
+type CarouselProps = Omit<WidgetProps, "ooui"> & {
+  ooui: CarouselOoui;
+  responsiveBehaviour?: boolean;
+};
+
+export const Carousel = (props: CarouselProps) => {
+  const { ooui, responsiveBehaviour = false } = props;
+
+  return (
+    <CustomCarousel autoplay={ooui.autoPlay} dots autoplaySpeed={5000}>
+      {ooui.items.map((group: GroupOoui, index: number) => (
+        <Container
+          key={index}
+          container={group.container}
+          responsiveBehaviour={responsiveBehaviour}
+        />
+      ))}
+    </CustomCarousel>
+  );
+};
+
+const CustomCarousel = styled(AntCarousel)`
+  .slick-dots li button {
+    background-color: ${mapToken.colorPrimary};
+  }
+  .slick-dots li.slick-active button {
+    background-color: ${mapToken.colorPrimary};
+  }
+  .slick-dots-bottom {
+    bottom: -15px;
+  }
+`;


### PR DESCRIPTION
This pull request introduces a new `Carousel` widget to the codebase. The changes include importing the `Carousel` component, exporting it for use, and integrating it into the widget factory.

https://github.com/user-attachments/assets/42e93eab-e5e3-4204-98e9-1f362692bed2


Key changes:

### Import and Export Updates:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R55): Added import and export statements for the new `Carousel` component. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R55) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R183)
* [`src/widgets/WidgetFactory.tsx`](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R39): Imported the `Carousel` component and added it to the `getWidgetType` function to recognize the new widget type. [[1]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R39) [[2]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R137-R138)

### New Component:
* [`src/widgets/custom/Carousel.tsx`](diffhunk://#diff-63d39828c8cbf3399a8db507d3958515ccd0b96486a62869871e357f237acf85R1-R42): Implemented the `Carousel` component using `AntCarousel` from the `antd` library, with custom styling and support for responsive behavior.

### Related
- Depends on https://github.com/gisce/ooui/pull/153
- Closes https://github.com/gisce/webclient/issues/1505