### PR TITLE
update gisce/ooui to v2.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.22.0",
+        "@gisce/ooui": "2.24.0",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.8.5",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.22.0.tgz",
-      "integrity": "sha512-q7ZUY7hMBQtTo+E+SJ3blVnsSdYKf7oMPn+ppwWXLLXoZBZEWI52qkNXO6ukGl3l6YjftujmE0AFN3U4sICpgg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.24.0.tgz",
+      "integrity": "sha512-2a3lzDqi5dbTn1rsEF+XZy/OkKlxdG6V7glK3dSCgblx+lxcUKKm02GQ7y5wUvK1H/m5BS7h53lAXAlvZlt0KQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.22.0",
+    "@gisce/ooui": "2.24.0",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.8.5",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.24.0](https://github.com/gisce/ooui/releases/tag/v2.24.0).