### PR TITLE
Add height and scroll if overflow to the group component

### DIFF
--- a/src/widgets/containers/Group.tsx
+++ b/src/widgets/containers/Group.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Group as GroupOoui } from "@gisce/ooui";
 import { Spinner } from "@/widgets/custom/Spinner";
-import { FieldSet , useLocale } from "@gisce/react-formiga-components";
+import { FieldSet, useLocale } from "@gisce/react-formiga-components";
 import iconMapper from "@/helpers/iconMapper";
 
 type Props = {
@@ -15,7 +15,13 @@ function Group(props: Props): React.ReactElement {
   const icon: React.ElementType | undefined = iconMapper(ooui.icon || "");
   const { t } = useLocale();
   return (
-    <>
+    <div
+      style={{
+        height: ooui.height ? ooui.height + "px" : "100%",
+        overflowX: "hidden",
+        overflowY: "auto",
+      }}
+    >
       {(ooui.label || icon) && showLabel ? (
         <FieldSet label={ooui.label} icon={icon}>
           <Spinner
@@ -31,7 +37,7 @@ function Group(props: Props): React.ReactElement {
           responsiveBehaviour={responsiveBehaviour}
         />
       )}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
This pull request includes changes to the `Group` component in the `src/widgets/containers/Group.tsx` file to enhance its layout and scrolling behavior.

Layout and scrolling improvements:

* Wrapped the component's return content in a `div` with inline styles to set the height and control the overflow behavior. This ensures the component has a defined height and enables vertical scrolling while hiding horizontal overflow. [[1]](diffhunk://#diff-b1fcab73136e9bd79dbe9d523271c98426a90e64aea2e063b333b264178558faL18-R24) [[2]](diffhunk://#diff-b1fcab73136e9bd79dbe9d523271c98426a90e64aea2e063b333b264178558faL34-R40)

## Related
- Depends on https://github.com/gisce/ooui/pull/160
- Closes https://github.com/gisce/webclient/issues/1518