### PR TITLE
update gisce/ooui to v2.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.25.0",
+        "@gisce/ooui": "2.26.0",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.25.0.tgz",
-      "integrity": "sha512-rAtNF0Zml+6WIOiwztjFEvgGROD/sWPie8WedDwe+kl+pFW9EknNi/SJBRAo/HFKNq8YbfWt7QBfzrNj+LeSZg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.26.0.tgz",
+      "integrity": "sha512-NtQ2BcAvHqxGu4hfJr/CtNjwvJceCV44nv7Fphchr3GNEHINX1EkwgSQtqThVS2HeMCc8Ni00NITwrWaH57OMw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.25.0",
+    "@gisce/ooui": "2.26.0",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.26.0](https://github.com/gisce/ooui/releases/tag/v2.26.0).