### PR TITLE
update gisce/ooui to v2.26.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.26.0",
+        "@gisce/ooui": "2.26.0-alpha.2",
         "@gisce/react-formiga-components": "1.8.0",
         "@gisce/react-formiga-table": "1.9.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.26.0.tgz",
-      "integrity": "sha512-NtQ2BcAvHqxGu4hfJr/CtNjwvJceCV44nv7Fphchr3GNEHINX1EkwgSQtqThVS2HeMCc8Ni00NITwrWaH57OMw==",
+      "version": "2.26.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.26.0-alpha.2.tgz",
+      "integrity": "sha512-RdeWfWtqZaqgShCX74shxx5QzaUqKomTu5zlPKdpyBNMfZeS4mpGLGPT+SC25TYWr6ymVz0r6nN2Fis9g565dw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.26.0",
+    "@gisce/ooui": "2.26.0-alpha.2",
     "@gisce/react-formiga-components": "1.8.0",
     "@gisce/react-formiga-table": "1.9.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.26.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.26.0-alpha.2).