### PR TITLE
update gisce/react-formiga-table to v1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.27.0",
         "@gisce/react-formiga-components": "1.8.0",
-        "@gisce/react-formiga-table": "1.9.0",
+        "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.0.tgz",
-      "integrity": "sha512-jKMW2i3rbYThoHQpSIAyaQORsRI6opcLDHMMQAPr33fm/6WoYHTsCkccH7RTZQONC/hGfQQoS7hlSUCKu2Oweg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.1.tgz",
+      "integrity": "sha512-5f3Z+OoGV7lh7ed3TVhatO4Dwrr0nf7jgMnLT69ZZLEg9QUzePyGn4seUfVt8ZsLlt4Hn2jJRtbGm+P32gRnzg==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.27.0",
     "@gisce/react-formiga-components": "1.8.0",
-    "@gisce/react-formiga-table": "1.9.0",
+    "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.9.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.9.1).