### PR TITLE
feat: enhance Notebook component with styled elements

### DIFF
--- a/src/widgets/containers/Notebook.tsx
+++ b/src/widgets/containers/Notebook.tsx
@@ -1,10 +1,32 @@
 import React from "react";
-import { Tabs } from "antd";
+import { Tabs, theme } from "antd";
+import styled from "styled-components";
 import iconMapper from "@/helpers/iconMapper";
 
 import { Notebook as NotebookOoui, Group as GroupOoui } from "@gisce/ooui";
 import { Group } from "@/index";
 const { TabPane } = Tabs;
+
+const StyledTabs = styled(Tabs)<{ borderRadius?: string }>`
+  .ant-tabs-content-holder {
+    border-left: 1px solid rgba(228, 228, 231, var(--tw-border-opacity));
+    border-right: 1px solid rgba(228, 228, 231, var(--tw-border-opacity));
+    border-bottom: 1px solid rgba(228, 228, 231, var(--tw-border-opacity));
+    padding: 15px;
+    border-bottom-left-radius: ${(props) => props.borderRadius || "5px"};
+    border-bottom-right-radius: ${(props) => props.borderRadius || "5px"};
+    margin-top: -1px;
+  }
+
+  .ant-tabs > .ant-tabs-nav {
+    /* So that there is no gap between the content and tabs */
+    margin-bottom: 0;
+  }
+
+  .ant-tabs-nav {
+    margin-bottom: 0 !important;
+  }
+`;
 
 type Props = {
   ooui: NotebookOoui;
@@ -14,6 +36,7 @@ type Props = {
 function Notebook(props: Props): React.ReactElement {
   const { ooui, responsiveBehaviour } = props;
   const tabs = ooui.pages;
+  const { token } = theme.useToken();
 
   function getPageIcon(icon: string) {
     if (icon) {
@@ -24,7 +47,11 @@ function Notebook(props: Props): React.ReactElement {
   }
 
   return (
-    <Tabs defaultActiveKey="1" tabPosition={ooui.tabPosition}>
+    <StyledTabs
+      defaultActiveKey="1"
+      tabPosition={ooui.tabPosition}
+      borderRadius={`${token.borderRadius}px`}
+    >
       {tabs
         .filter((page: any) => !page.invisible)
         .map((page: any) => {
@@ -45,7 +72,7 @@ function Notebook(props: Props): React.ReactElement {
             </TabPane>
           );
         })}
-    </Tabs>
+    </StyledTabs>
   );
 }
 


### PR DESCRIPTION
Closes: https://github.com/gisce/webclient/issues/1103
Needs: https://github.com/gisce/react-formiga-components/pull/16

- Added styled-components to Notebook for improved tab styling and border radius.
- Introduced theme token usage in Notebook for dynamic styling.

These changes aim to enhance the UI consistency and maintainability of the components.