### PR TITLE
update gisce/react-formiga-components to v1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.27.0",
-        "@gisce/react-formiga-components": "1.8.0",
+        "@gisce/react-formiga-components": "1.9.0",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3384,9 +3384,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.8.0.tgz",
-      "integrity": "sha512-bsLp9sa4WEGgHsb/jhog5JRDDgKwgtkouw11ZQD86SdRS5hhO4Ri1gVmmPUO8dM4wLZdOBst1S//4o4jYb9pHw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.9.0.tgz",
+      "integrity": "sha512-khyUsa+VAgMYSbgnEGyZmi2rx0dgkrBpjLOk+SUSnbJCzRzbc4X8yfjPVbve3Au+LCsxvVE76sxFYKnbGTPTKQ==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.27.0",
-    "@gisce/react-formiga-components": "1.8.0",
+    "@gisce/react-formiga-components": "1.9.0",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.9.0](https://github.com/gisce/react-formiga-components/releases/tag/v1.9.0).