### PR TITLE
Better color for visualitzation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@gisce/react-ooui",
       "version": "2.52.2",
       "dependencies": {
+        "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.27.0",
@@ -116,11 +117,11 @@
       }
     },
     "node_modules/@ant-design/colors": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.2.tgz",
-      "integrity": "sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.0.tgz",
+      "integrity": "sha512-bjTObSnZ9C/O8MB/B4OUtd/q9COomuJAR2SYfhxLyHvCKn4EKwCN3e+fWGMo7H5InAyV0wL17jdE9ALrdOW/6A==",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.6.1"
+        "@ant-design/fast-color": "^2.0.6"
       }
     },
     "node_modules/@ant-design/cssinjs": {
@@ -139,6 +140,17 @@
       "peerDependencies": {
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
       }
     },
     "node_modules/@ant-design/icons": {
@@ -2387,9 +2399,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "analyze": "vite-bundle-visualizer"
   },
   "dependencies": {
+    "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.27.0",

--- a/src/helpers/formHelper.ts
+++ b/src/helpers/formHelper.ts
@@ -1,5 +1,6 @@
 import { One2manyItem } from "@/widgets/base/one2many/One2manyInput";
 import { Form as FormOoui } from "@gisce/ooui";
+import { generate } from "@ant-design/colors";
 
 const filteredValues = (values: any, fields: any) => {
   if (!fields) {
@@ -267,6 +268,17 @@ export const colorFromString = (text: string): string => {
     hexColour += ("00" + value.toString(16)).slice(-2);
   }
   return hexColour;
+};
+
+export const getTextAndBackgroundColors = (
+  color: string,
+  intensity: number = 7,
+) => {
+  const colors = generate(color);
+  return {
+    text: colors[intensity],
+    background: `${color}40`,
+  };
 };
 
 export const colorTextFromBackground = (color: string) => {

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -3,7 +3,11 @@ import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { Tag as AntdTag, TagProps } from "antd";
 import { isPresetStatusColor, isPresetColor } from "antd/lib/_util/colors";
-import { colorFromString, colorFromBoolean } from "@/helpers/formHelper";
+import {
+  colorFromString,
+  colorFromBoolean,
+  getTextAndBackgroundColors,
+} from "@/helpers/formHelper";
 import { useLocale } from "@gisce/react-formiga-components";
 
 function capitalizeFirstLetter(text: string): string {
@@ -51,13 +55,14 @@ export const CustomTag = (props: TagProps) => {
   let { color } = props;
   let style = {};
   if (!isPresetStatusColor(props.color) && !isPresetColor(props.color)) {
+    const colors = getTextAndBackgroundColors(color as string);
     style = {
-      color,
-      borderColor: color,
+      color: colors.text,
+      borderColor: colors.text,
       borderStyle: "solid",
       borderWidth: "1px",
     };
-    color = `${color}20`;
+    color = colors.background;
   }
   return (
     <AntdTag {...props} style={style} color={color}>

--- a/src/widgets/custom/Tags.tsx
+++ b/src/widgets/custom/Tags.tsx
@@ -6,7 +6,11 @@ import { One2manyItem, One2manyValue } from "../base/one2many/One2manyInput";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import { FormContext, FormContextType } from "@/context/FormContext";
 import { Alert, Select } from "antd";
-import { colorFromString, transformPlainMany2Ones } from "@/helpers/formHelper";
+import {
+  colorFromString,
+  transformPlainMany2Ones,
+  getTextAndBackgroundColors,
+} from "@/helpers/formHelper";
 import ConnectionProvider from "@/ConnectionProvider";
 import { CustomTag } from "@/widgets/custom/Tag";
 
@@ -128,13 +132,14 @@ export const TagsInput = (props: TagsInputProps) => {
       event.stopPropagation();
     };
     const color = colorFromString(label);
+    const colors = getTextAndBackgroundColors(color);
     return (
       <CustomTag
         color={color}
         onMouseDown={onPreventMouseDown}
         closable={closable}
         onClose={onClose}
-        closeIcon={<span style={{ color }}>X</span>}
+        closeIcon={<span style={{ color: colors.text }}>X</span>}
       >
         {label}
       </CustomTag>


### PR DESCRIPTION
This pull request includes several changes to improve the color handling and styling in the application by integrating the `@ant-design/colors` library. The most important changes include adding a new dependency, updating helper functions, and modifying components to use the new color functions.

### Dependency Addition:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36): Added `@ant-design/colors` as a new dependency.

### Helper Functions:
* [`src/helpers/formHelper.ts`](diffhunk://#diff-f2c594f1322c5692c35c31894204b91f1a20a2c8097ba8ff70a5d830dde4f32eR3): Imported `generate` from `@ant-design/colors` and added a new function `getTextAndBackgroundColors` to generate text and background colors based on a given color and intensity. [[1]](diffhunk://#diff-f2c594f1322c5692c35c31894204b91f1a20a2c8097ba8ff70a5d830dde4f32eR3) [[2]](diffhunk://#diff-f2c594f1322c5692c35c31894204b91f1a20a2c8097ba8ff70a5d830dde4f32eR273-R283)

### Component Updates:
* [`src/widgets/custom/Tag.tsx`](diffhunk://#diff-9a1260f40c6de947fd5b712bf754ce61ec0a15259052ef8b22dae2f0abcda23dL6-R10): Updated the `CustomTag` component to use the new `getTextAndBackgroundColors` function for setting text and background colors. [[1]](diffhunk://#diff-9a1260f40c6de947fd5b712bf754ce61ec0a15259052ef8b22dae2f0abcda23dL6-R10) [[2]](diffhunk://#diff-9a1260f40c6de947fd5b712bf754ce61ec0a15259052ef8b22dae2f0abcda23dR58-R65)
* [`src/widgets/custom/Tags.tsx`](diffhunk://#diff-1d38dcf73d35bf151780d50cf12da2337f235960816340688ff6a90488a2059cL9-R13): Updated the `TagsInput` component to use the new `getTextAndBackgroundColors` function for setting the color of the close icon. [[1]](diffhunk://#diff-1d38dcf73d35bf151780d50cf12da2337f235960816340688ff6a90488a2059cL9-R13) [[2]](diffhunk://#diff-1d38dcf73d35bf151780d50cf12da2337f235960816340688ff6a90488a2059cR135-R142)


## Related

- Closes https://github.com/gisce/webclient/issues/1565