### PR TITLE
Support date/datetime/time fields on label widgets to human dates

### DIFF
--- a/src/helpers/dayjs.ts
+++ b/src/helpers/dayjs.ts
@@ -8,6 +8,9 @@ import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
 import weekday from "dayjs/plugin/weekday";
 import localeData from "dayjs/plugin/localeData";
+import "dayjs/locale/es";
+import "dayjs/locale/en";
+import "dayjs/locale/ca";
 
 dayjs.extend(advancedFormat);
 dayjs.extend(customParseFormat);

--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -5,6 +5,7 @@ import { QuestionCircleOutlined } from "@ant-design/icons";
 import { Label as LabelOoui } from "@gisce/ooui";
 import { FormContext, FormContextType } from "@/context/FormContext";
 import { Interweave } from "interweave";
+import dayjs from "dayjs";
 const { Text, Title } = Typography;
 const { useToken } = theme;
 
@@ -28,6 +29,13 @@ const Label = (props: Props) => {
   let labelText = addColon && label.length > 1 ? label + " :" : label;
   if (!ooui.fieldForLabel && ooui._id) {
     labelText = formContext.getFieldValue(ooui._id);
+    if (
+      ooui.fieldType === "date" ||
+      ooui.fieldType === "time" ||
+      ooui.fieldType === "datetime"
+    ) {
+      labelText = labelText ? dayjs(labelText).fromNow() : "";
+    }
   }
   const responsiveAlign = responsiveBehaviour ? "left" : "right";
   const labelAlgin = align || (fieldForLabel ? responsiveAlign : "left");

--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { Tooltip, Typography, theme } from "antd";
 import { WidgetProps } from "@/types";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 import { Label as LabelOoui } from "@gisce/ooui";
 import { FormContext, FormContextType } from "@/context/FormContext";
 import { Interweave } from "interweave";
-import dayjs from "dayjs";
+import dayjs from "@/helpers/dayjs";
 const { Text, Title } = Typography;
 const { useToken } = theme;
 


### PR DESCRIPTION
This pull request includes changes to the `src/widgets/base/Label.tsx` file, focusing on improving date and time formatting within labels. The most important changes include adding a new import for the `dayjs` library and modifying the label text formatting to use `dayjs` for date, time, and datetime fields.

### Enhancements to date and time formatting:

* [`src/widgets/base/Label.tsx`](diffhunk://#diff-64f1ff350daa57852626b27e94ce64f5626cc46342578dcd1433754616b91cbbR8): Added an import for the `dayjs` library to handle date and time formatting.
* [`src/widgets/base/Label.tsx`](diffhunk://#diff-64f1ff350daa57852626b27e94ce64f5626cc46342578dcd1433754616b91cbbR32-R38): Modified the `Label` component to format the label text using `dayjs` for fields of type `date`, `time`, and `datetime`.