### PR TITLE
ArrowSteps: better colors

### DIFF
--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -38,8 +38,8 @@ export const ArrowSteps = (props: ArrowStepsProps) => {
   const stepStyle = (isActive: boolean): React.CSSProperties => ({
     position: "relative",
     padding: "10px 30px 10px 40px",
-    backgroundColor: isActive ? colorPrimaryBg : colorFillSecondary,
-    color: isActive ? colorPrimaryText : colorText,
+    backgroundColor: isActive ? colorPrimaryText : colorFillSecondary,
+    color: isActive ? colorPrimaryBg : colorText,
     borderTop: `1px solid ${colorBgContainer}`,
     borderBottom: `1px solid ${colorBgContainer}`,
     width: "32%",
@@ -65,7 +65,9 @@ export const ArrowSteps = (props: ArrowStepsProps) => {
     top: 0,
     left: "100%",
     zIndex: 20,
-    borderLeft: `16px solid ${isActive ? colorPrimaryBg : colorFillSecondary}`,
+    borderLeft: `16px solid ${
+      isActive ? colorPrimaryText : colorFillSecondary
+    }`,
     borderTop: "16px solid transparent",
     borderBottom: "16px solid transparent",
   });


### PR DESCRIPTION
This pull request includes changes to the `ArrowSteps` component in the `src/widgets/custom/ArrowSteps.tsx` file. The changes primarily involve swapping the colors used for the background and text when a step is active, as well as updating the border color for the active state.

Changes to `ArrowSteps` component:

* Swapped the `backgroundColor` and `color` properties for active steps to use `colorPrimaryText` and `colorPrimaryBg` respectively.
* Updated the `borderLeft` property to use `colorPrimaryText` instead of `colorPrimaryBg` for active steps.

## Before

![image](https://github.com/user-attachments/assets/60de41df-ef52-4640-9e1c-bfece1ca1eb2)


## After
![image](https://github.com/user-attachments/assets/44bc724e-31b9-4ccf-91bf-2834e035ad76)

## Related

- Closes https://github.com/gisce/webclient/issues/1627
