### PR TITLE
Comments: allow icon in timeline

### DIFF
--- a/src/stories/custom/Comments.stories.tsx
+++ b/src/stories/custom/Comments.stories.tsx
@@ -1,11 +1,11 @@
 // @ts-ignore
 import React from "react";
-import LocaleProvider from "../../context/LocaleContext";
 import {
   Comments,
   CommentsTimeline,
   EventsType,
 } from "../../widgets/custom/Comments";
+import { Comments as CommentsOOui } from "@gisce/ooui";
 
 export default {
   title: "Components/Widgets/Custom/Comments",
@@ -88,11 +88,7 @@ export const Default = (): React.ReactElement => {
       isAuthor: false,
     },
   ];
-  return (
-    <LocaleProvider lang="es_ES">
-      <Comments data={data} />
-    </LocaleProvider>
-  );
+  return <Comments data={data} />;
 };
 
 export const Timeline = () => {
@@ -154,6 +150,7 @@ export const Timeline = () => {
     },
     {
       type: "comment",
+      icon: "mail",
       event: {
         id: 4,
         text:
@@ -183,15 +180,17 @@ export const Timeline = () => {
     },
     {
       type: "action",
+      icon: "close",
       event: {
         action: "Close",
         date: "2023-04-01 13:35:00",
       },
     },
   ] as EventsType[];
-  return (
-    <LocaleProvider lang="es_ES">
-      <CommentsTimeline value={data} />
-    </LocaleProvider>
-  );
+  const ooui = new CommentsOOui({
+    props: {
+      name: "comments",
+    },
+  });
+  return <CommentsTimeline value={data} ooui={ooui} />;
 };

--- a/src/widgets/custom/Comments.tsx
+++ b/src/widgets/custom/Comments.tsx
@@ -15,6 +15,7 @@ import { useLocale } from "@gisce/react-formiga-components";
 
 import dayjs from "@/helpers/dayjs";
 import md5 from "md5";
+import iconMapper from "@/helpers/iconMapper";
 
 const { Meta } = Card;
 const { Text } = Typography;
@@ -60,6 +61,7 @@ type EventActionType = {
 
 export type EventsType = {
   type: "action" | "comment";
+  icon?: string;
   event: EventActionType | CommentDataType;
 };
 
@@ -125,12 +127,18 @@ export const Comments = (props: CommentsTypeProps) => {
   );
 };
 
+const getIcon = (icon: string): React.ReactElement => {
+  const Icon: React.ElementType = iconMapper(icon) as any;
+  return Icon && <Icon />;
+};
+
 export const CommentsTimeline = (props: CommentsTimelineProps) => {
   const { value, ooui } = props;
   const items = (value || []).map((i) => {
     if (i.type === "action") {
       return {
         children: `${i.event.date} - ${(i.event as EventActionType).action}`,
+        dot: i.icon ? getIcon(i.icon) : undefined,
       };
     } else if (i.type === "comment") {
       return {
@@ -138,6 +146,7 @@ export const CommentsTimeline = (props: CommentsTimelineProps) => {
         position: (i.event as CommentDataType).isSender ? "left" : "right",
         label: i.event.date,
         children: <Comment data={i.event as CommentDataType} />,
+        dot: i.icon ? getIcon(i.icon) : undefined,
       };
     }
   });


### PR DESCRIPTION
This pull request includes several changes to the `Comments` component adding icons to events

Key changes:


### Addition of Icons to Events:

* Added `icon` property to `EventsType` in `src/widgets/custom/Comments.tsx` to support event icons.
* Updated `CommentsTimeline` to display icons using the `getIcon` helper function.


![image](https://github.com/user-attachments/assets/0d43a452-31ee-4e6a-8acf-6d82e67a110f)
