### PR TITLE
update gisce/ooui to v2.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.27.0",
+        "@gisce/ooui": "2.27.1",
         "@gisce/react-formiga-components": "1.9.2",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.27.0.tgz",
-      "integrity": "sha512-XJ7wKjq/gr58/CP2b62Z+233pWiEHyWQccm9W0Is79Gmq4awyZU7XJv9T37bxls+N7AXFR6uKcT/UIJj3NyTwg==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.27.1.tgz",
+      "integrity": "sha512-i80nAgB7lAKqbDMgLPXcOmS3a4Jxd17H0KUzUg5SQZv5WcgAzfDuGii3E+mpItV5oLwOGuk523YCVt2PJgnRAg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.27.0",
+    "@gisce/ooui": "2.27.1",
     "@gisce/react-formiga-components": "1.9.2",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.27.1](https://github.com/gisce/ooui/releases/tag/v2.27.1).