### PR TITLE
fix: adjust value key filtering in URL sharing

### DIFF
--- a/src/context/TabManagerContext.tsx
+++ b/src/context/TabManagerContext.tsx
@@ -79,6 +79,7 @@ const TabManagerProvider = (props: TabManagerProviderProps): any => {
   useEffect(() => {
     if (noTabs) {
       document.title = title;
+      window.history.replaceState({}, "", "/");
     }
   }, [noTabs, title]);
 

--- a/src/helpers/shareUrlHelper.ts
+++ b/src/helpers/shareUrlHelper.ts
@@ -3,7 +3,18 @@ import { ActionInfo, ActionRawData } from "@/types";
 const OPEN_ACTION_PATH = "action";
 // Parameters to exclude from the URL
 const ALLOWED_VALUES_KEYS = ["active_id", "active_ids", "id", "parent_id"];
-const IGNORED_PARAMS = ["target", "context", "domain", "fields"];
+const ALLOWED_PARAMETERS = [
+  "model",
+  "views",
+  "title",
+  "initialView",
+  "action_id",
+  "action_type",
+  "res_id",
+  "limit",
+  "actionRawData",
+  "searchParams",
+];
 
 export const createShareOpenUrl = (action: ActionInfo) => {
   const url = new URL(window.location.origin);
@@ -15,13 +26,10 @@ export const createShareOpenUrl = (action: ActionInfo) => {
       action?.actionRawData && filterActionRawData(action.actionRawData),
   };
 
-  // Add all non-null properties from action to URL
-  Object.entries(finalAction).forEach(([key, value]) => {
-    if (
-      !IGNORED_PARAMS.includes(key) &&
-      value &&
-      (!Array.isArray(value) || value.length > 0)
-    ) {
+  // Filter allowed parameters and add them to URL
+  const allowedParams = filterAllowedParameters(finalAction);
+  Object.entries(allowedParams).forEach(([key, value]) => {
+    if (value && (!Array.isArray(value) || value.length > 0)) {
       url.searchParams.set(key, convertToString(value));
     }
   });
@@ -82,6 +90,17 @@ const filterActionRawData = (actionRawData: ActionRawData) => {
 
   // Return undefined if no properties were added to filteredData
   return Object.keys(filteredData).length > 0 ? filteredData : undefined;
+};
+
+export const filterAllowedParameters = (parameters: any) => {
+  if (!parameters || typeof parameters !== "object") {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(parameters).filter(([key]) =>
+      ALLOWED_PARAMETERS.includes(key),
+    ),
+  );
 };
 
 export const filterAllowedValues = (values: any) => {

--- a/src/helpers/shareUrlHelper.ts
+++ b/src/helpers/shareUrlHelper.ts
@@ -7,7 +7,7 @@ const ALLOWED_PARAMETERS = [
   "model",
   "views",
   "title",
-  "initialView",
+  "initialViewId",
   "action_id",
   "action_type",
   "res_id",
@@ -33,6 +33,9 @@ export const createShareOpenUrl = (action: ActionInfo) => {
       url.searchParams.set(key, convertToString(value));
     }
   });
+
+  action.initialView?.id &&
+    url.searchParams.set("initialViewId", action.initialView?.id.toString());
 
   return url.toString();
 };

--- a/src/helpers/shareUrlHelper.ts
+++ b/src/helpers/shareUrlHelper.ts
@@ -2,7 +2,7 @@ import { ActionInfo, ActionRawData } from "@/types";
 
 const OPEN_ACTION_PATH = "action";
 // Parameters to exclude from the URL
-const ALLOWED_VALUES_KEYS = ["active_id", "active_ids", "id"];
+const ALLOWED_VALUES_KEYS = ["active_id", "active_ids", "id", "parent_id"];
 const IGNORED_PARAMS = ["target", "context", "domain", "fields"];
 
 export const createShareOpenUrl = (action: ActionInfo) => {

--- a/src/hooks/useUrlFromCurrentTab.ts
+++ b/src/hooks/useUrlFromCurrentTab.ts
@@ -29,6 +29,24 @@ export function useUrlFromCurrentTab({
   };
 
   const { action_id } = currentTab.action;
+
+  let finalValues = currentTab.action.values || {};
+  const formValues = formRef.current?.getPlainValues() || {};
+
+  // For tree view with active_ids, action values have priority over form values
+  if (initialView.type === "tree" && finalValues.active_ids) {
+    finalValues = {
+      ...formValues,
+      ...finalValues,
+    };
+  } else {
+    // For all other cases, form values (if any) have priority over action values
+    finalValues = {
+      ...finalValues,
+      ...formValues,
+    };
+  }
+
   const finalActionData: ActionInfo = {
     ...currentTab.action,
     ...(initialView && { initialView }),
@@ -36,10 +54,7 @@ export function useUrlFromCurrentTab({
     ...(currentId && { res_id: currentId }),
     actionRawData: {
       ...currentTab.action.actionRawData,
-      values: {
-        ...currentTab.action.values,
-        ...(formRef.current?.getPlainValues() || {}),
-      },
+      values: finalValues,
     },
   };
 

--- a/src/hooks/useUrlFromCurrentTab.ts
+++ b/src/hooks/useUrlFromCurrentTab.ts
@@ -13,7 +13,8 @@ export function useUrlFromCurrentTab({
 }: {
   currentTab?: Tab;
 }): UseUrlFromCurrentTabResult {
-  const { currentView, searchParams, currentId } = useActionViewContext();
+  const { currentView, searchParams, currentId, formRef } =
+    useActionViewContext();
   const { currentTab: currentTabContext } = useTabs();
 
   const currentTab = currentTabProps || currentTabContext;
@@ -33,6 +34,13 @@ export function useUrlFromCurrentTab({
     ...(initialView && { initialView }),
     ...(searchParams && { searchParams }),
     ...(currentId && { res_id: currentId }),
+    actionRawData: {
+      ...currentTab.action.actionRawData,
+      values: {
+        ...currentTab.action.values,
+        ...(formRef.current?.getPlainValues() || {}),
+      },
+    },
   };
 
   const shareUrl = createShareOpenUrl(finalActionData);

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import { ErpAllFeatureKeys, ErpFeatureKeys } from "./models/erpFeature";
 import type { ErpFeaturesMap } from "./models/erpFeature";
 import { GraphCard } from "./widgets/views/Graph";
 import dayjs from "./helpers/dayjs";
+import { filterAllowedParameters , filterAllowedValues } from "./helpers/shareUrlHelper";
 
 export {
   Button,
@@ -183,4 +184,6 @@ export {
   Spinner,
   Carousel,
   ColorPicker,
+  filterAllowedParameters,
+  filterAllowedValues,
 };

--- a/src/views/RootView.tsx
+++ b/src/views/RootView.tsx
@@ -83,9 +83,10 @@ function RootView(props: RootViewProps, ref: any) {
       context: rootContext,
     });
 
-    let values: Record<string, any> = filterAllowedValues(
-      actionRawData?.values,
-    );
+    let values: Record<string, any> = {
+      ...(filterAllowedValues(actionRawData?.values) || {}),
+      ...globalValues,
+    };
 
     const finalIdToRead: number | undefined =
       res_id || values.active_id || values.id;
@@ -112,7 +113,7 @@ function RootView(props: RootViewProps, ref: any) {
         parseContext({
           context: actionRawData.context,
           fields,
-          values: { ...globalValues, ...(values || {}) },
+          values,
         });
     } else {
       parsedContext = {};
@@ -133,7 +134,7 @@ function RootView(props: RootViewProps, ref: any) {
         ) {
           return await ConnectionProvider.getHandler().evalDomain({
             domain: actionRawData.domain,
-            values: { ...(values || {}), ...globalValues },
+            values,
             context: { ...rootContext, ...parsedContext },
             fields,
           });

--- a/src/widgets/views/Form.tsx
+++ b/src/widgets/views/Form.tsx
@@ -287,8 +287,8 @@ function Form(props: FormProps, ref: any) {
   }
 
   function getPlainValues() {
-    const values: any = getValues();
-    const fields: any = getFields();
+    const values: any = getValues() || {};
+    const fields: any = getFields() || {};
     const reformattedValues: { [key: string]: any } = {};
 
     Object.keys(values).forEach((key) => {


### PR DESCRIPTION
- Added "parent_id" to the allowed values keys in URL parameters
- Updated useUrlFromCurrentTab to include form values in the actionRawData.
- Modified RootView to merge filtered values with global values
- Ensured getPlainValues in Form handles potential null values for getValues and getFields.