### PR TITLE
feat: export processAction from ContentRootProvider

### DIFF
--- a/src/context/ContentRootContext.tsx
+++ b/src/context/ContentRootContext.tsx
@@ -74,6 +74,7 @@ const ContentRootProvider = (
 
   useImperativeHandle(ref, () => ({
     openActionModal,
+    processAction,
   }));
 
   // Action modal state
@@ -172,7 +173,9 @@ const ContentRootProvider = (
     onRefreshParentValues?: any;
   }) {
     const { type } = actionData;
-    onRefreshParentValues.current.push(onRefreshParentValuesFn);
+    if (onRefreshParentValuesFn) {
+      onRefreshParentValues.current.push(onRefreshParentValuesFn);
+    }
 
     if (type === "ir.actions.report.xml") {
       return await generateReport({
@@ -224,7 +227,7 @@ const ContentRootProvider = (
             fields,
             values: { ...values, ...globalValues },
           })
-        : actionData.context;
+        : actionData?.context || {};
 
     const mergedContext = {
       ...context,
@@ -283,6 +286,7 @@ const ContentRootProvider = (
         initialView,
         action_id: actionData.id,
         action_type: actionData.type,
+        res_id: actionData.res_id,
       });
 
       return { closeParent: true };

--- a/src/views/RootView.tsx
+++ b/src/views/RootView.tsx
@@ -48,6 +48,7 @@ function RootView(props: RootViewProps, ref: any) {
   useImperativeHandle(ref, () => ({
     retrieveAndOpenAction,
     openShortcut,
+    processAction: (contentRootProvider.current as any).processAction,
   }));
 
   function remove(key: string) {


### PR DESCRIPTION
https://github.com/gisce/webclient/issues/1658
- Added processAction method to ContentRootProvider for improved action handling.
- Updated onRefreshParentValues to check for function existence before pushing.
- Ensured actionData.context is safely accessed to prevent potential errors.
- Included res_id in the action parameters