### PR TITLE
Label: use human_date prop and add title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.27.1",
+        "@gisce/ooui": "2.28.0",
         "@gisce/react-formiga-components": "1.9.2",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.27.1.tgz",
-      "integrity": "sha512-i80nAgB7lAKqbDMgLPXcOmS3a4Jxd17H0KUzUg5SQZv5WcgAzfDuGii3E+mpItV5oLwOGuk523YCVt2PJgnRAg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.28.0.tgz",
+      "integrity": "sha512-ENTSc9GcBQ3uRUe0gBR3XsvSmzXJVWiHY13lG/zpPS8iahk6+JtDVDf3XjG1YPj+0JExfTMniz+viBFNNL5hBQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.27.1",
+    "@gisce/ooui": "2.28.0",
     "@gisce/react-formiga-components": "1.9.2",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -27,6 +27,7 @@ const Label = (props: Props) => {
   const formContext = useContext(FormContext) as FormContextType;
   const addColon = fieldForLabel !== null;
   let labelText = addColon && label.length > 1 ? label + " :" : label;
+  let labelTitle = "";
   if (!ooui.fieldForLabel && ooui._id) {
     labelText = formContext.getFieldValue(ooui._id);
     if (
@@ -34,7 +35,22 @@ const Label = (props: Props) => {
       ooui.fieldType === "time" ||
       ooui.fieldType === "datetime"
     ) {
-      labelText = labelText ? dayjs(labelText).fromNow() : "";
+      const formats = {
+        date: "DD/MM/YYYY",
+        time: "HH:mm",
+        datetime: "DD/MM/YYYY HH:mm",
+      };
+      labelTitle = labelText
+        ? dayjs(labelText).format(
+            formats[ooui.fieldType as keyof typeof formats],
+          )
+        : "";
+      if (ooui.humanDate) {
+        labelText = labelText ? dayjs(labelText).fromNow() : "";
+      } else {
+        labelText = labelTitle;
+        labelTitle = "";
+      }
     }
   }
   const responsiveAlign = responsiveBehaviour ? "left" : "right";
@@ -57,7 +73,7 @@ const Label = (props: Props) => {
           />
         </Tooltip>
       )}
-      <span className="pr-2">
+      <span className="pr-2" title={labelTitle}>
         <TextType level={labelSize} type={labelType as any}>
           <Interweave content={labelText} />
         </TextType>


### PR DESCRIPTION
This pull request includes updates to the `Label` component in the `src/widgets/base/Label.tsx` file to enhance the display of date, time, and datetime fields. The most important changes are the addition of a formatted title attribute and the handling of human-readable dates.

Enhancements to date, time, and datetime fields:

* Added `labelTitle` to store formatted date, time, or datetime values using `dayjs` for tooltip display.
* Updated the `span` element to include a `title` attribute with the `labelTitle` to show the formatted date, time, or datetime on hover.

## Related

- Requires: https://github.com/gisce/ooui/pull/169