### PR TITLE
Tag: use colorField to define the tag color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.28.0",
+        "@gisce/ooui": "2.29.0",
         "@gisce/react-formiga-components": "1.9.2",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.28.0.tgz",
-      "integrity": "sha512-ENTSc9GcBQ3uRUe0gBR3XsvSmzXJVWiHY13lG/zpPS8iahk6+JtDVDf3XjG1YPj+0JExfTMniz+viBFNNL5hBQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.29.0.tgz",
+      "integrity": "sha512-k1xuecga3x7nvXsoTwyopV5DmRu5D9LK8I9XV8/X5a40wtGP2kdagL3cJZFxX7dCsYDQNnbeYU/rKjgPRjcV7A==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.28.0",
+    "@gisce/ooui": "2.29.0",
     "@gisce/react-formiga-components": "1.9.2",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/custom/Tag.tsx
+++ b/src/widgets/custom/Tag.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext, useState, useEffect, useCallback } from "react";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
 import { Tag as AntdTag, TagProps } from "antd";
@@ -8,6 +8,9 @@ import {
   colorFromBoolean,
   getTextAndBackgroundColors,
 } from "@/helpers/formHelper";
+import { useNetworkRequest } from "@/hooks/useNetworkRequest";
+import ConnectionProvider from "@/ConnectionProvider";
+import { FormContext, FormContextType } from "@/context/FormContext";
 import { useLocale } from "@gisce/react-formiga-components";
 
 function capitalizeFirstLetter(text: string): string {
@@ -25,7 +28,13 @@ export const Tag = (props: WidgetProps) => {
 
 export const TagInput = (props: any) => {
   const { t } = useLocale();
+  const [readObjects, cancelReadObjectsRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().readObjects,
+  );
+  const { getFieldValue } = (useContext(FormContext) as FormContextType) || {};
   const { ooui, value } = props;
+  const [color, setColor] = useState<string>("default");
+
   let formattedValue = value;
   let colorMethod: any = colorFromString;
   let colorValue = value;
@@ -41,13 +50,42 @@ export const TagInput = (props: any) => {
     colorMethod = colorFromBoolean;
   }
 
+  const updateColor = useCallback(async () => {
+    if (ooui.colorField) {
+      if (ooui.fieldType === "many2one" && ooui.raw_props?.relation) {
+        const response = await readObjects({
+          model: ooui.raw_props.relation,
+          ids: [value[0]],
+          fieldsToRetrieve: [ooui.colorField],
+        });
+        const retrievedColor = response[0]?.[ooui.colorField];
+
+        if (retrievedColor) {
+          const sanitizedColor = retrievedColor.includes("#")
+            ? retrievedColor
+            : `#${retrievedColor}`;
+          setColor(sanitizedColor);
+        }
+      } else {
+        setColor(getFieldValue(ooui.colorField));
+      }
+    } else {
+      setColor(
+        ooui.colors === "auto"
+          ? colorMethod(colorValue)
+          : ooui.colors[colorValue] || colorMethod(colorValue),
+      );
+    }
+  }, [ooui?.colorField]);
+
+  useEffect(() => {
+    updateColor().catch((err) => console.error(err));
+  }, [ooui?.colorField]);
+
   if (!formattedValue) {
     return null;
   }
-  const color =
-    ooui.colors === "auto"
-      ? colorMethod(colorValue)
-      : ooui.colors[colorValue] || colorMethod(colorValue);
+
   return <CustomTag color={color}>{formattedValue}</CustomTag>;
 };
 


### PR DESCRIPTION
This pull request includes several enhancements to the `Tag` component in the `src/widgets/custom/Tag.tsx` file. The main changes involve adding new hooks and context to handle network requests and dynamic color updates for tags.

### Enhancements to `Tag` component:

* **Imports Update:**
  - Added `useContext`, `useState`, `useEffect`, and `useCallback` from React.
  - Imported `useNetworkRequest` hook, `ConnectionProvider`, and `FormContext` for handling network requests and form context.

* **State and Context Integration:**
  - Introduced `readObjects` and `cancelReadObjectsRequest` using `useNetworkRequest` to fetch data.
  - Integrated `FormContext` to access form field values.

* **Dynamic Color Update:**
  - Added a `useState` hook to manage the tag color state.
  - Implemented `updateColor` function using `useCallback` to fetch and set the tag color based on the `ooui.colorField`.
  - Added a `useEffect` hook to call `updateColor` whenever `ooui.colorField` changes.

These changes enhance the functionality of the `Tag` component by allowing it to dynamically update its color based on the context and network data.

## Related

- Requires https://github.com/gisce/ooui/pull/172
- Closes https://github.com/gisce/webclient/issues/1753