### PR TITLE
update gisce/ooui to v2.29.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.28.0",
+        "@gisce/ooui": "2.29.0-alpha.1",
         "@gisce/react-formiga-components": "1.9.2",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.28.0.tgz",
-      "integrity": "sha512-ENTSc9GcBQ3uRUe0gBR3XsvSmzXJVWiHY13lG/zpPS8iahk6+JtDVDf3XjG1YPj+0JExfTMniz+viBFNNL5hBQ==",
+      "version": "2.29.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.29.0-alpha.1.tgz",
+      "integrity": "sha512-au9e5WwUw4oRNDzJusBoft2fzYtjh9wSgunX022ONcNGHSruc/l0TG+0PDvt59qelyTK1cZv2dDLaLmUTXjMfA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.28.0",
+    "@gisce/ooui": "2.29.0-alpha.1",
     "@gisce/react-formiga-components": "1.9.2",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.29.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.29.0-alpha.1).