### PR TITLE
Millores de l'indicador

### DIFF
--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -14,6 +14,7 @@ import { useFeatureIsEnabled } from "@/context/ConfigContext";
 import { ErpFeatureKeys } from "@/models/erpFeature";
 import { GraphServer } from "../views/Graph/GraphServer";
 import { Many2oneSuffix } from "@/widgets/base/many2one/Many2oneSuffix";
+import { useLocale } from "@gisce/react-formiga-components";
 import {
   TabManagerContext,
   TabManagerContextType,
@@ -55,6 +56,7 @@ type IndicatorInputProps = {
 const IndicatorInput = (props: IndicatorInputProps) => {
   const { token } = useToken();
   const { ooui, value } = props;
+  const { locale } = useLocale();
   const title = (
     <>
       <span>{ooui.label} </span>
@@ -95,6 +97,17 @@ const IndicatorInput = (props: IndicatorInputProps) => {
         <Many2oneSuffix id={value[0]} model={ooui.raw_props.relation} />
       </Space>
     );
+  }
+  if (value && (ooui.fieldType === "float" || ooui.fieldType === "integer")) {
+    try {
+      formattedValue = new Intl.NumberFormat(
+        locale.replaceAll("_", "-"),
+        {},
+      ).format(value);
+    } catch (e) {
+      console.log("Error formatting number with locale", locale);
+      console.error(e);
+    }
   }
   const field = (
     <Statistic

--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect } from "react";
-import { Tooltip, theme, Statistic, Card, Empty } from "antd";
+import { Tooltip, theme, Statistic, Card, Empty, Space } from "antd";
 import { Indicator as IndicatorOoui } from "@gisce/ooui";
 import { WidgetProps } from "@/types";
 import Field from "@/common/Field";
@@ -13,6 +13,7 @@ import ErrorBoundary from "antd/es/alert/ErrorBoundary";
 import { useFeatureIsEnabled } from "@/context/ConfigContext";
 import { ErpFeatureKeys } from "@/models/erpFeature";
 import { GraphServer } from "../views/Graph/GraphServer";
+import { Many2oneSuffix } from "@/widgets/base/many2one/Many2oneSuffix";
 import {
   TabManagerContext,
   TabManagerContextType,
@@ -87,12 +88,21 @@ const IndicatorInput = (props: IndicatorInputProps) => {
       ? dayjs(value).format(formats[ooui.fieldType as keyof typeof formats])
       : " ";
   }
+  if (ooui.fieldType === "many2one" && value && ooui.raw_props?.relation) {
+    formattedValue = (
+      <Space>
+        {formattedValue}
+        <Many2oneSuffix id={value[0]} model={ooui.raw_props.relation} />
+      </Space>
+    );
+  }
   const field = (
     <Statistic
       title={title}
       prefix={Icon && <Icon />}
       suffix={ooui.suffix}
       value={formattedValue}
+      formatter={(value) => value}
     />
   );
   if (ooui.card) {

--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -20,6 +20,7 @@ import {
 import { GraphCard } from "../views/Graph";
 import { useFormContext } from "@/context/FormContext";
 import styled from "styled-components";
+import dayjs from "@/helpers/dayjs";
 const { useToken } = theme;
 
 type IndicatorProps = WidgetProps & {
@@ -72,6 +73,19 @@ const IndicatorInput = (props: IndicatorInputProps) => {
     formattedValue = ooui.selectionValues.get(value);
   } else if (Array.isArray(value)) {
     formattedValue = value[1];
+  } else if (
+    ooui.fieldType === "date" ||
+    ooui.fieldType === "time" ||
+    ooui.fieldType === "datetime"
+  ) {
+    const formats = {
+      date: "DD/MM/YYYY",
+      time: "HH:mm",
+      datetime: "DD/MM/YYYY HH:mm",
+    };
+    formattedValue = value
+      ? dayjs(value).format(formats[ooui.fieldType as keyof typeof formats])
+      : " ";
   }
   const field = (
     <Statistic


### PR DESCRIPTION
- Suport per camps tipus, `date`, `datetime` i `time`
  ![image](https://github.com/user-attachments/assets/7c3a8c2b-8afe-4db7-900b-bb2a168b1d08)

- Mostrar el `Many2OneSuffix` si és un *many2one*
  ![image](https://github.com/user-attachments/assets/1ff59593-137d-4973-99ee-8fb093df5939)



## Related
- Closes https://github.com/gisce/webclient/issues/1774
- Closes https://github.com/gisce/webclient/issues/1779