### PR TITLE
Many2One: allow to open in form in a new tab

### DIFF
--- a/src/widgets/base/many2one/Many2oneSuffix.tsx
+++ b/src/widgets/base/many2one/Many2oneSuffix.tsx
@@ -32,7 +32,7 @@ export const Many2oneSuffix = (props: Props) => {
   const tabManagerContext = useContext(
     TabManagerContext,
   ) as TabManagerContextType;
-  const { openRelate } = tabManagerContext || {};
+  const { openRelate, openAction } = tabManagerContext || {};
 
   const contentRootContext = useContext(
     ContentRootContext,
@@ -104,6 +104,20 @@ export const Many2oneSuffix = (props: Props) => {
     };
 
     switch (type) {
+      case "open":
+        openAction({
+          domain: [["id", "=", id]],
+          context,
+          model,
+          res_id: id,
+          title: formView?.title || "",
+          views: [[formView?.view_id, "form"]],
+          target: "current",
+          initialView: { type: "form" },
+          action_id: -1,
+          action_type: "ir.actions.act_window",
+        });
+        break;
       case "action":
         processAction?.({
           actionData: item,

--- a/src/widgets/base/many2one/Many2oneSuffixOoui.tsx
+++ b/src/widgets/base/many2one/Many2oneSuffixOoui.tsx
@@ -3,6 +3,7 @@ import {
   PrinterOutlined,
   ThunderboltOutlined,
   EnterOutlined,
+  ExportOutlined,
 } from "@ant-design/icons";
 import {
   useLocale,
@@ -28,7 +29,7 @@ export type ActionRelatePrint = {
 
 export type Many2OneSuffixOnItemClickOpts = {
   item: DropdownMenuItem;
-  type: "action" | "print" | "relate";
+  type: "action" | "print" | "relate" | "open";
 };
 
 type Many2oneSuffixProps = {
@@ -70,6 +71,11 @@ export const Many2oneSuffixOoui = ({
         sticky: true,
         items: [
           {
+            id: "open",
+            name: t("open"),
+            icon: <ExportOutlined />,
+          },
+          {
             id: "action",
             name: t("action"),
             disabled: !actionItems || actionItems.length === 0,
@@ -104,6 +110,8 @@ export const Many2oneSuffixOoui = ({
             setActionModalVisible(true);
           } else if (item.id === "print") {
             setPrintModalVisible(true);
+          } else if (item.id === "open") {
+            onItemClick?.({ item, type: "open" });
           } else {
             onItemClick?.({ item, type: "relate" });
           }


### PR DESCRIPTION
This pull request introduces new functionality to the `Many2oneSuffix` and `Many2oneSuffixOoui` components in the `src/widgets/base/many2one` directory. The primary change is the addition of an "open" action, which allows users to open items directly from the dropdown menu. The most important changes include updates to the context, type definitions, and the dropdown menu items.

https://github.com/user-attachments/assets/8cfea386-d9b2-44bf-9f5c-02e8cb8463ba


### Enhancements to `Many2oneSuffix` component:

* [`src/widgets/base/many2one/Many2oneSuffix.tsx`](diffhunk://#diff-d0525199d1c31c32a9cb1a691e2c445e4af6cc4b5c342912de695a7bf8ff4c8fL35-R35): Added `openAction` to the `tabManagerContext` and implemented a new case for the "open" action in the switch statement. [[1]](diffhunk://#diff-d0525199d1c31c32a9cb1a691e2c445e4af6cc4b5c342912de695a7bf8ff4c8fL35-R35) [[2]](diffhunk://#diff-d0525199d1c31c32a9cb1a691e2c445e4af6cc4b5c342912de695a7bf8ff4c8fR107-R120)

### Enhancements to `Many2oneSuffixOoui` component:

* [`src/widgets/base/many2one/Many2oneSuffixOoui.tsx`](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afR6): Imported `ExportOutlined` icon and added "open" to the `Many2OneSuffixOnItemClickOpts` type. [[1]](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afR6) [[2]](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afL31-R32)
* [`src/widgets/base/many2one/Many2oneSuffixOoui.tsx`](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afR73-R77): Added "open" to the dropdown menu items and updated the click handler to support the new "open" action. [[1]](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afR73-R77) [[2]](diffhunk://#diff-e19e6ad923efc1da4ede3fc520400a6e3a42cd4424ec0eee65aaa7bcc2b3e0afR113-R114)

## Related

- Closes https://github.com/gisce/webclient/issues/1776