### PR TITLE
Format number with the user locale

### DIFF
--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -14,6 +14,7 @@ import { useFeatureIsEnabled } from "@/context/ConfigContext";
 import { ErpFeatureKeys } from "@/models/erpFeature";
 import { GraphServer } from "../views/Graph/GraphServer";
 import { Many2oneSuffix } from "@/widgets/base/many2one/Many2oneSuffix";
+import { useLocale } from "@gisce/react-formiga-components";
 import {
   TabManagerContext,
   TabManagerContextType,
@@ -55,6 +56,7 @@ type IndicatorInputProps = {
 const IndicatorInput = (props: IndicatorInputProps) => {
   const { token } = useToken();
   const { ooui, value } = props;
+  const { locale } = useLocale();
   const title = (
     <>
       <span>{ooui.label} </span>
@@ -95,6 +97,17 @@ const IndicatorInput = (props: IndicatorInputProps) => {
         <Many2oneSuffix id={value[0]} model={ooui.raw_props.relation} />
       </Space>
     );
+  }
+  if (value && (ooui.fieldType === "float" || ooui.fieldType === "integer")) {
+    try {
+      formattedValue = new Intl.NumberFormat(
+        locale.replaceAll("_", "-"),
+        {},
+      ).format(value);
+    } catch (e) {
+      console.log("Error formatting number with locale", locale);
+      console.error(e);
+    }
   }
   const field = (
     <Statistic


### PR DESCRIPTION
> [!NOTE]
> Aquesta pull-request fa merge contra https://github.com/gisce/react-ooui/pull/879 per entrar totes les millores del `Indicator` de forma conjunta


This pull request includes updates to the `src/widgets/custom/Indicator.tsx` file to enhance locale-based number formatting. The changes primarily involve importing a new locale hook and using it to format numerical values based on the user's locale.

Enhancements to locale-based number formatting:

* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R17): Imported `useLocale` from `@gisce/react-formiga-components` to access locale settings.
* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R59): Added `locale` to the `IndicatorInput` component's properties by using the `useLocale` hook.
* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R101-R111): Implemented number formatting using `Intl.NumberFormat` based on the locale, with error handling for formatting issues.

## Related
- Closes https://github.com/gisce/webclient/issues/1779