### PR TITLE
update gisce/react-formiga-components to v1.10.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.29.0",
-        "@gisce/react-formiga-components": "1.9.2",
+        "@gisce/react-formiga-components": "1.10.0-alpha.3",
         "@gisce/react-formiga-table": "1.9.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3397,9 +3397,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.9.2.tgz",
-      "integrity": "sha512-jrEa8/f7F9H8tja3lGwrwB+JVD/Cx0ZviKIKvsYPu9+ptsfgqv3iZvXT1Yf0xG8/Xhwr6G2FWzR9JUxyYdLcJw==",
+      "version": "1.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.10.0-alpha.3.tgz",
+      "integrity": "sha512-PJ6GxD6nA6fjmiOayGliX32RBeKNzDDjbY9IUoAkhQNa8XHyqQX9YtZ1hhBM3C3bsVC1astIyo5Lfc6ta0JFAg==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.29.0",
-    "@gisce/react-formiga-components": "1.9.2",
+    "@gisce/react-formiga-components": "1.10.0-alpha.3",
     "@gisce/react-formiga-table": "1.9.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.10.0-alpha.3](https://github.com/gisce/react-formiga-components/releases/tag/v1.10.0-alpha.3).