### PR TITLE
update gisce/react-formiga-table to v1.10.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.29.0",
         "@gisce/react-formiga-components": "1.9.2",
-        "@gisce/react-formiga-table": "1.9.1",
+        "@gisce/react-formiga-table": "1.10.0-alpha.3",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.9.1.tgz",
-      "integrity": "sha512-5f3Z+OoGV7lh7ed3TVhatO4Dwrr0nf7jgMnLT69ZZLEg9QUzePyGn4seUfVt8ZsLlt4Hn2jJRtbGm+P32gRnzg==",
+      "version": "1.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.10.0-alpha.3.tgz",
+      "integrity": "sha512-PV8e/vDV7bkN2izHuwa/JnaSEGzBcLspXk69XQcLypwpANMPxxWx6TvYsgEYpvVKDFwVAD9ZZHOY5hdB/y5VzQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.29.0",
     "@gisce/react-formiga-components": "1.9.2",
-    "@gisce/react-formiga-table": "1.9.1",
+    "@gisce/react-formiga-table": "1.10.0-alpha.3",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.10.0-alpha.3](https://github.com/gisce/react-formiga-table/releases/tag/v1.10.0-alpha.3).