### PR TITLE
Markdown: fix url encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-dom": "18.2.0",
         "react-grid-layout": "^1.3.4",
         "react-hotkeys-hook": "^4.5.0",
-        "react-markdown": "^9.0.0",
+        "react-markdown": "^9.0.1",
         "react-measure": "^2.5.2",
         "remark-gfm": "^4.0.0",
         "styled-components": "5.3.5",
@@ -24291,16 +24291,15 @@
       }
     },
     "node_modules/react-markdown": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.0.tgz",
-      "integrity": "sha512-v6yNf3AB8GfJ8lCpUvzxAXKxgsHpdmWPlcVRQ6Nocsezp255E/IDrF31kLQsPJeB/cKto/geUwjU36wH784FCA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
+      "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
         "html-url-attributes": "^3.0.0",
         "mdast-util-to-hast": "^13.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
         "unified": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-dom": "18.2.0",
     "react-grid-layout": "^1.3.4",
     "react-hotkeys-hook": "^4.5.0",
-    "react-markdown": "^9.0.0",
+    "react-markdown": "^9.0.1",
     "react-measure": "^2.5.2",
     "remark-gfm": "^4.0.0",
     "styled-components": "5.3.5",


### PR DESCRIPTION
- Update `react-markdown` to [`9.0.1`](https://github.com/remarkjs/react-markdown/releases/tag/9.0.1)
- Closes https://github.com/gisce/webclient/issues/1744