### PR TITLE
Steps: allow use in json fields like ArrowSteps

### DIFF
--- a/src/widgets/custom/ArrowSteps.tsx
+++ b/src/widgets/custom/ArrowSteps.tsx
@@ -6,8 +6,14 @@ import iconMapper from "@/helpers/iconMapper";
 
 type ArrowStepsFieldProps = WidgetProps;
 
+export type ArrowStepsValue = Array<{
+  title: string;
+  active: boolean;
+  icon?: string;
+}>;
+
 type ArrowStepsProps = {
-  value?: Array<{ title: string; active: boolean; icon?: string }>;
+  value?: ArrowStepsValue;
 };
 
 export const ArrowSteps = (props: ArrowStepsProps) => {

--- a/src/widgets/custom/Steps.tsx
+++ b/src/widgets/custom/Steps.tsx
@@ -3,6 +3,7 @@ import { Steps as AntdSteps } from "antd";
 import { FormContext, FormContextType } from "@/context/FormContext";
 import Field from "@/common/Field";
 import { Steps as StepsOoui } from "@gisce/ooui";
+import { ArrowStepsValue } from "@/widgets/custom/ArrowSteps";
 
 type StepsProps = {
   ooui: StepsOoui;
@@ -23,7 +24,7 @@ export const Steps = (props: StepsProps) => {
 };
 
 type StepsInputProps = StepsProps & {
-  value?: any;
+  value?: Map<string, string> | ArrowStepsValue;
 };
 
 export const StepsInput = (props: StepsInputProps) => {
@@ -31,8 +32,15 @@ export const StepsInput = (props: StepsInputProps) => {
   const { selectionValues, errorField, lastStep } = ooui as StepsOoui;
   const formContext = useContext(FormContext) as FormContextType;
 
-  const values = Array.from(selectionValues.entries());
-  const current = values.map((val) => val[0]).indexOf(value);
+  let values: Array<[string, string]> = [];
+  let current: number | undefined;
+  if (ooui.fieldType === "json") {
+    values = (value as ArrowStepsValue).map((val) => [val.title, val.title]);
+    current = (value as ArrowStepsValue).findIndex((val) => val.active);
+  } else {
+    values = Array.from(selectionValues.entries());
+    current = values.map((val) => val[0]).indexOf(value);
+  }
   let status: StatusType = "process";
   let error = "";
 


### PR DESCRIPTION
This pull request includes changes to the `ArrowSteps` and `Steps` components to improve the handling of step values and their types. The most important changes include the introduction of a new type `ArrowStepsValue` and adjustments to the `StepsInput` component to handle different types of values.

### Changes to ArrowSteps component:

* [`src/widgets/custom/ArrowSteps.tsx`](diffhunk://#diff-98f5f74be566e40f7c5f5aef49a88db5d63a1353033bc06fafb24e399b450d64R9-R16): Introduced a new type `ArrowStepsValue` to define the structure of step values, which includes `title`, `active`, and an optional `icon`. Updated the `ArrowStepsProps` to use this new type.

### Changes to Steps component:

* [`src/widgets/custom/Steps.tsx`](diffhunk://#diff-61ae872ac94391934c22ffe85a72edc0b5ca3c8b9ef6569d9ba681b4ba74bc08R6): Imported the newly created `ArrowStepsValue` type.
* [`src/widgets/custom/Steps.tsx`](diffhunk://#diff-61ae872ac94391934c22ffe85a72edc0b5ca3c8b9ef6569d9ba681b4ba74bc08L26-R43): Updated the `StepsInputProps` type to accept either a `Map<string, string>` or `ArrowStepsValue` for the `value` property.
* [`src/widgets/custom/Steps.tsx`](diffhunk://#diff-61ae872ac94391934c22ffe85a72edc0b5ca3c8b9ef6569d9ba681b4ba74bc08L26-R43): Modified the `StepsInput` component to handle `ArrowStepsValue` when the `fieldType` is `json`, mapping the values and determining the current active step accordingly.


## Related

- Closes: https://github.com/gisce/webclient/issues/1824