### PR TITLE
Steps: when is json check if it has a value

### DIFF
--- a/src/widgets/custom/Steps.tsx
+++ b/src/widgets/custom/Steps.tsx
@@ -34,7 +34,7 @@ export const StepsInput = (props: StepsInputProps) => {
 
   let values: Array<[string, string]> = [];
   let current: number | undefined;
-  if (ooui.fieldType === "json") {
+  if (ooui.fieldType === "json" && value) {
     values = (value as ArrowStepsValue).map((val) => [val.title, val.title]);
     current = (value as ArrowStepsValue).findIndex((val) => val.active);
   } else {


### PR DESCRIPTION
This pull request includes a small change to the `StepsInput` component in the `src/widgets/custom/Steps.tsx` file. The change ensures that the `value` is checked before processing it when the `fieldType` is `json`.

* [`src/widgets/custom/Steps.tsx`](diffhunk://#diff-61ae872ac94391934c22ffe85a72edc0b5ca3c8b9ef6569d9ba681b4ba74bc08L37-R37): Added a condition to check if `value` is present before mapping and finding the index of `active` in `ArrowStepsValue`.