### PR TITLE
Tree: allow sort by many2one if feature is enabled

### DIFF
--- a/src/helpers/treeHelper.tsx
+++ b/src/helpers/treeHelper.tsx
@@ -7,6 +7,8 @@ import {
 } from "@gisce/ooui";
 import { TreeView, Column } from "@/types";
 import { SortDirection, ColumnState } from "@gisce/react-formiga-table";
+import { useFeatureIsEnabled } from "@/context/ConfigContext";
+import { ErpFeatureKeys } from "@/models/erpFeature";
 
 const getTree = (treeView: TreeView): TreeOoui => {
   const xml = treeView.arch;
@@ -32,6 +34,9 @@ const getTableColumns = (
   components: any,
   context: any,
 ): Column[] => {
+  const many2oneSortEnabled = useFeatureIsEnabled(
+    ErpFeatureKeys.FEATURE_MANY2ONE_SORT,
+  );
   const tableColumns = tree.columns.map((column) => {
     const type = column.type;
     const key = column.id;
@@ -78,7 +83,9 @@ const getTableColumns = (
         return 0;
       },
       isSortable:
-        type !== "one2many" && type !== "many2one" && !column.isFunction,
+        type !== "one2many" &&
+        !column.isFunction &&
+        (type !== "many2one" || many2oneSortEnabled),
     };
   });
   return tableColumns;

--- a/src/helpers/treeHelper.tsx
+++ b/src/helpers/treeHelper.tsx
@@ -33,10 +33,8 @@ const getTableColumns = (
   tree: TreeOoui,
   components: any,
   context: any,
+  many2oneSortEnabled: boolean = false,
 ): Column[] => {
-  const many2oneSortEnabled = useFeatureIsEnabled(
-    ErpFeatureKeys.FEATURE_MANY2ONE_SORT,
-  );
   const tableColumns = tree.columns.map((column) => {
     const type = column.type;
     const key = column.id;

--- a/src/models/erpFeature.ts
+++ b/src/models/erpFeature.ts
@@ -5,6 +5,7 @@ export enum ErpFeatureKeys {
   FEATURE_READFORVIEW = "read_for_view",
   FEATURE_USERVIEWPREFS = "user_view_prefs",
   FEATURE_GET_TOOLBAR = "get_toolbar",
+  FEATURE_MANY2ONE_SORT = "many2one_sort",
   // ... add more features here
 }
 

--- a/src/widgets/base/one2many/One2manyTree.tsx
+++ b/src/widgets/base/one2many/One2manyTree.tsx
@@ -23,6 +23,8 @@ import {
   getKey,
 } from "@/helpers/o2m-columnStorageHelper";
 import { useLocale } from "@gisce/react-formiga-components";
+import { useFeatureIsEnabled } from "@/context/ConfigContext";
+import { ErpFeatureKeys } from "@/models/erpFeature";
 
 export type One2manyTreeProps = {
   items: One2manyItem[];
@@ -89,6 +91,10 @@ export const One2manyTree = ({
   const itemsRef = useRef<One2manyItem[]>(items);
   const { t } = useLocale();
 
+  const many2oneSortEnabled = useFeatureIsEnabled(
+    ErpFeatureKeys.FEATURE_MANY2ONE_SORT,
+  );
+
   useDeepCompareEffect(() => {
     itemsRef.current = items;
     if (prevItemsValue.current === undefined) {
@@ -110,8 +116,9 @@ export const One2manyTree = ({
         ...COLUMN_COMPONENTS,
       },
       context,
+      many2oneSortEnabled,
     );
-  }, [context, ooui]);
+  }, [context, ooui, many2oneSortEnabled]);
 
   const onRequestData = useCallback(
     async ({

--- a/src/widgets/views/SearchTreeInfinite.tsx
+++ b/src/widgets/views/SearchTreeInfinite.tsx
@@ -52,6 +52,8 @@ import SearchFilter from "./searchFilter/SearchFilter";
 import { useSearchTreeState } from "@/hooks/useSearchTreeState";
 import { Tree as TreeOoui } from "@gisce/ooui";
 import { useAutorefreshableTreeFields } from "@/hooks/useAutorefreshableTreeFields";
+import { useFeatureIsEnabled } from "@/context/ConfigContext";
+import { ErpFeatureKeys } from "@/models/erpFeature";
 
 export const HEIGHT_OFFSET = 10;
 export const MAX_ROWS_TO_SELECT = 200;
@@ -143,6 +145,10 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
   const nameSearch = nameSearchProps || searchTreeNameSearch;
   const prevNameSearch = useRef(nameSearch);
 
+  const many2oneSortEnabled = useFeatureIsEnabled(
+    ErpFeatureKeys.FEATURE_MANY2ONE_SORT,
+  );
+
   useEffect(() => {
     updateTotalRows();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -192,8 +198,9 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
         ...COLUMN_COMPONENTS,
       },
       parentContext,
+      many2oneSortEnabled,
     );
-  }, [treeOoui, parentContext]);
+  }, [treeOoui, parentContext, many2oneSortEnabled]);
 
   const columnStateKey = useMemo(() => {
     if (loading) {

--- a/src/widgets/views/Tree/Tree.tsx
+++ b/src/widgets/views/Tree/Tree.tsx
@@ -32,6 +32,8 @@ import {
 import { SelectAllRecordsRow } from "@/common/SelectAllRecordsRow";
 import { COLUMN_COMPONENTS } from "./treeComponents";
 import ErrorBoundary from "antd/es/alert/ErrorBoundary";
+import { useFeatureIsEnabled } from "@/context/ConfigContext";
+import { ErpFeatureKeys } from "@/models/erpFeature";
 
 type Props = {
   total?: number;
@@ -102,6 +104,10 @@ export const UnmemoizedTree = forwardRef<TableRef, Props>(
     const { title = undefined, setTitle = undefined } =
       (rootTree ? actionViewContext : {}) || {};
 
+    const many2oneSortEnabled = useFeatureIsEnabled(
+      ErpFeatureKeys.FEATURE_MANY2ONE_SORT,
+    );
+
     const columns = useMemo(() => {
       if (!treeOoui) {
         return undefined;
@@ -113,8 +119,9 @@ export const UnmemoizedTree = forwardRef<TableRef, Props>(
           ...COLUMN_COMPONENTS,
         },
         context,
+        many2oneSortEnabled,
       );
-    }, [context, treeOoui]);
+    }, [treeOoui, context, many2oneSortEnabled]);
 
     useImperativeHandle(ref, () => ({
       unselectAll: () => {


### PR DESCRIPTION
This pull request introduces a new feature flag to enable sorting for "many2one" columns in the table view. The changes involve importing necessary modules, adding a new feature key, and updating the sorting logic based on the feature flag.

Key changes:

* Imports and feature flag:
  * [`src/helpers/treeHelper.tsx`](diffhunk://#diff-5260245ebbae0c25da2211d9d2e9ab448330da137c5fa8d01f3ac51de3f29b17R10-R11): Imported `useFeatureIsEnabled` from `ConfigContext` and `ErpFeatureKeys` from `erpFeature` model.

* Feature key addition:
  * [`src/models/erpFeature.ts`](diffhunk://#diff-90b94f4abde3b56e77bdd2dc9f45788c71da975d7363c0ce08ae7723f29bc7a9R8): Added `FEATURE_MANY2ONE_SORT` to the `ErpFeatureKeys` enum.

* Sorting logic update:
  * [`src/helpers/treeHelper.tsx`](diffhunk://#diff-5260245ebbae0c25da2211d9d2e9ab448330da137c5fa8d01f3ac51de3f29b17R37-R39): Added a check for the `many2oneSortEnabled` feature flag in the `getTableColumns` function to conditionally enable sorting for "many2one" columns. [[1]](diffhunk://#diff-5260245ebbae0c25da2211d9d2e9ab448330da137c5fa8d01f3ac51de3f29b17R37-R39) [[2]](diffhunk://#diff-5260245ebbae0c25da2211d9d2e9ab448330da137c5fa8d01f3ac51de3f29b17L81-R88)

## Related

- Closes https://github.com/gisce/webclient/issues/1250
- Backend code: https://github.com/gisce/erp/pull/23349