### PR TITLE
update gisce/react-formiga-components to v1.10.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.29.0",
-        "@gisce/react-formiga-components": "1.10.0-alpha.5",
+        "@gisce/react-formiga-components": "1.10.0-alpha.6",
         "@gisce/react-formiga-table": "1.10.0-alpha.5",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3397,9 +3397,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.10.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.10.0-alpha.5.tgz",
-      "integrity": "sha512-UfMcDdeYriNzuQ1bzV07cRl1ldA3j/TCeoz2udqPw8EIJBwcXMMg+i8mEA3TCxvjs7r/Z9wZ2+BGxnu9xHZcyw==",
+      "version": "1.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.10.0-alpha.6.tgz",
+      "integrity": "sha512-WuXUMtvWCbylR3JaPxJNR0AlnGwtrV0BFuOQUDor+Ymqi4RmKXUGah09PmkUzkJ1bcCPOFXejIACaZpOBoBnBw==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.29.0",
-    "@gisce/react-formiga-components": "1.10.0-alpha.5",
+    "@gisce/react-formiga-components": "1.10.0-alpha.6",
     "@gisce/react-formiga-table": "1.10.0-alpha.5",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.10.0-alpha.6](https://github.com/gisce/react-formiga-components/releases/tag/v1.10.0-alpha.6).