### PR TITLE
update gisce/react-formiga-table to v1.10.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.29.0",
         "@gisce/react-formiga-components": "1.10.0-alpha.5",
-        "@gisce/react-formiga-table": "1.10.0-alpha.5",
+        "@gisce/react-formiga-table": "1.10.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.10.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.10.0-alpha.5.tgz",
-      "integrity": "sha512-RaSMkN+rDFiAZjEiEJGtj8rCg6ZPguwL8mRjqvdCOVzAh+lwVl9aPbsH6ESaANBgP6hAyfjaCP/PlSUj0pPh4g==",
+      "version": "1.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.10.0-alpha.6.tgz",
+      "integrity": "sha512-XD4NPblvguHQq7CuesMQdfWDEI+AVIkLDXQnuj/k+o6+R1ozIPV61rpwhLW7fAy1y3uKWghdnBKuyFhtB675YA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.29.0",
     "@gisce/react-formiga-components": "1.10.0-alpha.5",
-    "@gisce/react-formiga-table": "1.10.0-alpha.5",
+    "@gisce/react-formiga-table": "1.10.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.10.0-alpha.6](https://github.com/gisce/react-formiga-table/releases/tag/v1.10.0-alpha.6).