### PR TITLE
update gisce/react-formiga-components to v1.11.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.29.1",
-        "@gisce/react-formiga-components": "1.10.0",
+        "@gisce/react-formiga-components": "1.11.0-alpha.1",
         "@gisce/react-formiga-table": "1.10.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3397,9 +3397,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.10.0.tgz",
-      "integrity": "sha512-QLv3mGI8pmoviZ5WDxwssMNYqQJ1FtQ2+2MYOOPlxeRj6zZgP6jljMQvl/MSNimwvX34Y2aEkJsqZEyxQuafVA==",
+      "version": "1.11.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.11.0-alpha.1.tgz",
+      "integrity": "sha512-Y8PQ3ff34PgSZcsrMdMZkTqWV8zywtmgj8geq8utOCCXU1frtnkLe7XRFEA3TYz6z4p4EuO4PsuEgD8zAeMnVA==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.29.1",
-    "@gisce/react-formiga-components": "1.10.0",
+    "@gisce/react-formiga-components": "1.11.0-alpha.1",
     "@gisce/react-formiga-table": "1.10.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.11.0-alpha.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.11.0-alpha.1).