### PR TITLE
Indicator: allow dynamic icon and colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.29.1",
+        "@gisce/ooui": "2.30.0",
         "@gisce/react-formiga-components": "1.10.0",
         "@gisce/react-formiga-table": "1.10.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3383,9 +3383,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.29.1.tgz",
-      "integrity": "sha512-Ho613tHE1WxP93miV4mxOFhHrTjqGzcBdLoZdmO9wPFW1Vs6QvKihRQyMZasYzmHpwZOk+SZWPc7U9qO3cW05Q==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.30.0.tgz",
+      "integrity": "sha512-H8rndsNUDsBqTI9hH1+GAxB0zhUM52m4vMoEN9gZYZIqpa0EjBeJ8aA1JhV9bo0ATOOszkemjSbMZtTnFAVCEQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.29.1",
+    "@gisce/ooui": "2.30.0",
     "@gisce/react-formiga-components": "1.10.0",
     "@gisce/react-formiga-table": "1.10.0",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -61,7 +61,7 @@ const IndicatorInput = (props: IndicatorInputProps) => {
   const { locale } = useLocale();
   const [icon, setIcon] = useState<string>(ooui.icon);
   const [color, setColor] = useState<string>(ooui.color);
-  const [parseCondition] = useNetworkRequest(
+  const [parseCondition, cancelRequest] = useNetworkRequest(
     ConnectionProvider.getHandler().parseCondition,
   );
 
@@ -84,6 +84,8 @@ const IndicatorInput = (props: IndicatorInputProps) => {
     }
     evaluateCondition(ooui.icon, setIcon);
     evaluateCondition(ooui.color, setColor);
+    return () => cancelRequest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ooui.icon, ooui.color, value]);
 
   const title = (

--- a/src/widgets/custom/Indicator.tsx
+++ b/src/widgets/custom/Indicator.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Tooltip, theme, Statistic, Card, Empty, Space } from "antd";
 import { Indicator as IndicatorOoui } from "@gisce/ooui";
 import { WidgetProps } from "@/types";
@@ -23,6 +23,8 @@ import { GraphCard } from "../views/Graph";
 import { useFormContext } from "@/context/FormContext";
 import styled from "styled-components";
 import dayjs from "@/helpers/dayjs";
+import { useNetworkRequest } from "@/hooks/useNetworkRequest";
+import ConnectionProvider from "@/ConnectionProvider";
 const { useToken } = theme;
 
 type IndicatorProps = WidgetProps & {
@@ -57,6 +59,33 @@ const IndicatorInput = (props: IndicatorInputProps) => {
   const { token } = useToken();
   const { ooui, value } = props;
   const { locale } = useLocale();
+  const [icon, setIcon] = useState<string>(ooui.icon);
+  const [color, setColor] = useState<string>(ooui.color);
+  const [parseCondition] = useNetworkRequest(
+    ConnectionProvider.getHandler().parseCondition,
+  );
+
+  useEffect(() => {
+    async function evaluateCondition(condition: string, setter: Function) {
+      if (condition && condition.includes(":")) {
+        try {
+          const iconEval = await parseCondition({
+            condition,
+            values: { value },
+            context: {},
+          });
+          setter(iconEval);
+        } catch (err) {
+          console.error("Error evaluando icono:", err);
+        }
+      } else {
+        setter(condition);
+      }
+    }
+    evaluateCondition(ooui.icon, setIcon);
+    evaluateCondition(ooui.color, setColor);
+  }, [ooui.icon, ooui.color, value]);
+
   const title = (
     <>
       <span>{ooui.label} </span>
@@ -70,7 +99,7 @@ const IndicatorInput = (props: IndicatorInputProps) => {
       )}
     </>
   );
-  const Icon: React.ElementType = iconMapper(ooui.icon) as any;
+  const Icon: React.ElementType = iconMapper(icon) as any;
   let formattedValue = value;
   if (ooui.selectionValues.size) {
     formattedValue = ooui.selectionValues.get(value);
@@ -116,6 +145,7 @@ const IndicatorInput = (props: IndicatorInputProps) => {
       suffix={ooui.suffix}
       value={formattedValue}
       formatter={(value) => value}
+      valueStyle={{ color }}
     />
   );
   if (ooui.card) {


### PR DESCRIPTION
This pull request includes significant updates to the `Indicator.tsx` file, adding new functionality and improving existing features. The most important changes include the addition of state management for icon and color, the introduction of a network request hook, and the dynamic evaluation of conditions for icons and colors.

State management and dynamic evaluation:

* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94L1-R1): Added `useState` to manage `icon` and `color` states.
* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R62-R88): Implemented `useEffect` to dynamically evaluate and set `icon` and `color` based on conditions using the `useNetworkRequest` hook. [[1]](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R62-R88) [[2]](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94L73-R102)

Network request integration:

* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R26-R27): Imported and used `useNetworkRequest` and `ConnectionProvider` to handle network requests for evaluating conditions.

UI updates:

* [`src/widgets/custom/Indicator.tsx`](diffhunk://#diff-035d5e34dfece9459f178de0ef8168c300d14f99a624a80d53b5481f93392e94R148): Updated `valueStyle` to dynamically change the color based on evaluated conditions.

## Related

- Requires https://github.com/gisce/ooui/pull/178
- Closes https://github.com/gisce/webclient/issues/1869