### PR TITLE
update gisce/ooui to v2.30.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.30.0-alpha.1",
+        "@gisce/ooui": "2.30.0-alpha.2",
         "@gisce/react-formiga-components": "1.10.0",
         "@gisce/react-formiga-table": "1.10.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3383,9 +3383,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.30.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.30.0-alpha.1.tgz",
-      "integrity": "sha512-XygV7RPUjyz9Li9es1CZVavKMPtQ8PId+sTryjAqrPWGTqyaJnViucasBSnBA3VdgKfgU+JsqNGq9iHe5ulzzA==",
+      "version": "2.30.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.30.0-alpha.2.tgz",
+      "integrity": "sha512-+Ekogih593E68CIugOZll4zNYGqX9/ny8gx7Sm86toL4UXB7xzrlZ+GM3nkflmVnXVI1igd7bDUEavzPsTuBjg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.30.0-alpha.1",
+    "@gisce/ooui": "2.30.0-alpha.2",
     "@gisce/react-formiga-components": "1.10.0",
     "@gisce/react-formiga-table": "1.10.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.30.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.30.0-alpha.2).