### PR TITLE
update gisce/react-formiga-table to v1.12.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.12.0-alpha.1",
-        "@gisce/react-formiga-table": "1.11.0-alpha.1",
+        "@gisce/react-formiga-table": "1.12.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.11.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.11.0-alpha.1.tgz",
-      "integrity": "sha512-UcGal/X1EOjN24IxxBxjkSySBCGbPUwLd6WtkWfTL1FV6Yar2yftVgFFkN6JqUX+GGHDhtUKoqkoq+zXhYiAlA==",
+      "version": "1.12.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.1.tgz",
+      "integrity": "sha512-x0ajmqZ/alrMxNcQ22yWoz5K+3cUw7F0wn9h96CJSvv0cTcZVTV3W21XIzft1WWY5NGBIm8I4rIa6oX9IYXd8g==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.12.0-alpha.1",
-    "@gisce/react-formiga-table": "1.11.0-alpha.1",
+    "@gisce/react-formiga-table": "1.12.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.12.0-alpha.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.12.0-alpha.1).