### PR TITLE
update gisce/react-formiga-table to v1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
         "@gisce/react-formiga-components": "1.11.0",
-        "@gisce/react-formiga-table": "1.11.0",
+        "@gisce/react-formiga-table": "1.11.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.11.0.tgz",
-      "integrity": "sha512-sOGGBxBxm4v6oaMlp0Nu+l3VjhdESwkOfd7X61sKjO4w5oCUqyVOsoONq32FYVTabrdXieIfIjtbNwH+Tko3Ag==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.11.1.tgz",
+      "integrity": "sha512-hulwQVBqiWPOgIOz7e/TkNx48imWtHWOJu7yJ4sWjhDOmzL8H8i4V2/HydPKeI/j/e/f0QhrLJJMSeuGiXuYqA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
     "@gisce/react-formiga-components": "1.11.0",
-    "@gisce/react-formiga-table": "1.11.0",
+    "@gisce/react-formiga-table": "1.11.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.11.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.11.1).