### PR TITLE
update gisce/react-formiga-table to v1.12.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.12.0-alpha.1",
-        "@gisce/react-formiga-table": "1.12.0-alpha.3",
+        "@gisce/react-formiga-table": "1.12.0-alpha.4",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.12.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.3.tgz",
-      "integrity": "sha512-TKYijUW+EEp2ul7HD+Fbg1+eUCd6NelI8KritHpNoH41pd8EzqlsoOlyL7R5XCde1Qbe3lI+6/LgC1cUfcygig==",
+      "version": "1.12.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.4.tgz",
+      "integrity": "sha512-wVLANL4y+cLnUwgnqEaN4Hu/OmQ/g8s8VZ/iE8L0uQIBYNuYtmCzPz6YuJx+N+e0YXhXfNA4i8iCa6QgCXhPEw==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.12.0-alpha.1",
-    "@gisce/react-formiga-table": "1.12.0-alpha.3",
+    "@gisce/react-formiga-table": "1.12.0-alpha.4",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.12.0-alpha.4](https://github.com/gisce/react-formiga-table/releases/tag/v1.12.0-alpha.4).