### PR TITLE
update gisce/react-formiga-table to v1.12.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.12.0-alpha.2",
-        "@gisce/react-formiga-table": "1.12.0-alpha.5",
+        "@gisce/react-formiga-table": "1.12.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.12.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.5.tgz",
-      "integrity": "sha512-yBeuNAWe9ICq6+Q/lSSPZrwWG23H2a0+f1KqgovKjtq1dyUKSY4r/FjiGV1PyNiskp4f0l/34vQYsWfELM5Iew==",
+      "version": "1.12.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.6.tgz",
+      "integrity": "sha512-WcSmgTehQIiMB5TFZDPKFCMa4/r2nNE1N4JhBsnJHEA1BnFVIHx/OIIofHERXPDvr51AlHN5QaaQQnhmzdk1Sg==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.12.0-alpha.2",
-    "@gisce/react-formiga-table": "1.12.0-alpha.5",
+    "@gisce/react-formiga-table": "1.12.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.12.0-alpha.6](https://github.com/gisce/react-formiga-table/releases/tag/v1.12.0-alpha.6).