### PR TITLE
update gisce/react-formiga-table to v1.12.0-alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.12.0-alpha.2",
-        "@gisce/react-formiga-table": "1.12.0-alpha.6",
+        "@gisce/react-formiga-table": "1.12.0-alpha.7",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.12.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.6.tgz",
-      "integrity": "sha512-WcSmgTehQIiMB5TFZDPKFCMa4/r2nNE1N4JhBsnJHEA1BnFVIHx/OIIofHERXPDvr51AlHN5QaaQQnhmzdk1Sg==",
+      "version": "1.12.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.7.tgz",
+      "integrity": "sha512-kkDUFwcShT9/ndZJRI5/yCkh70DHfcppi6PgxCcAUynWW+WTHO6Guq9hvVYyNg66aCP1zoIMH6Gy4iwyRDISPA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.12.0-alpha.2",
-    "@gisce/react-formiga-table": "1.12.0-alpha.6",
+    "@gisce/react-formiga-table": "1.12.0-alpha.7",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.12.0-alpha.7](https://github.com/gisce/react-formiga-table/releases/tag/v1.12.0-alpha.7).