### PR TITLE
update gisce/react-formiga-table to v1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
         "@gisce/react-formiga-components": "1.11.1",
-        "@gisce/react-formiga-table": "1.11.3",
+        "@gisce/react-formiga-table": "1.12.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.11.3.tgz",
-      "integrity": "sha512-xQuK9Ho1k3uRBXV/QddOTdRGcLEmXNnIiuGpzt+27X0dRQhg75WgkXIs+TMaU4pz6aunr0t3KSkjxzRKiTKdoQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0.tgz",
+      "integrity": "sha512-sCJ2iOAj0ea0JXxHa+3BAJsLfAtSsxF9iUW/yCFF5g/ChvckwEzpJtImyPE7kC/8v0HA5qEEgA/OdlPcoW5PAA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
     "@gisce/react-formiga-components": "1.11.1",
-    "@gisce/react-formiga-table": "1.11.3",
+    "@gisce/react-formiga-table": "1.12.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.12.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.12.0).