### PR TITLE
update gisce/react-formiga-table to v1.13.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.12.0-alpha.2",
-        "@gisce/react-formiga-table": "1.12.0-alpha.8",
+        "@gisce/react-formiga-table": "1.13.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.12.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.12.0-alpha.8.tgz",
-      "integrity": "sha512-vz2vno6lDLkm/Da0Pnlj9eRK9t1JyNs6eMFEZo6sbUURHUrM0lySrHDqX9Ojqc5qWJ7eCJUYq0dvfs6Ett0gBw==",
+      "version": "1.13.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.13.0-alpha.1.tgz",
+      "integrity": "sha512-HdKxRR+Y8fu9mlaRK1SjYRcPpBg1s5MTgDotpqzAR2U2k3owuUWpjhafOL9UvIpxI3fJRjKqY/T0vkn2MU1BMA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.12.0-alpha.2",
-    "@gisce/react-formiga-table": "1.12.0-alpha.8",
+    "@gisce/react-formiga-table": "1.13.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.13.0-alpha.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.13.0-alpha.1).