### PR TITLE
fix: handle undefined field definitions in useExport hook

### DIFF
--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -127,6 +127,12 @@ export const useExport = ({
         fields: pExport.fields.map((field: PredefinedExportField) => {
           const childKey = getChildKey(field.key);
           const fieldDefinition = getFieldDefinition(field.key, fields.current);
+          if (!fieldDefinition) {
+            return {
+              key: field.key,
+            };
+          }
+
           const optsForField = fieldDefinition[childKey];
 
           if (!optsForField) {
@@ -288,7 +294,7 @@ const getFieldDefinition = (key: string, fields: any) => {
   if (key.indexOf("/") === -1) {
     return fields["/"];
   } else {
-    return fields[getParentKey(key)];
+    return fields?.[getParentKey(key)];
   }
 };
 


### PR DESCRIPTION
https://github.com/gisce/webclient/issues/2001
Added a check for undefined field definitions in the useExport hook to ensure that the application can gracefully handle cases where a field key does not have a corresponding definition. This prevents potential errors during export operations.