### PR TITLE
update gisce/react-formiga-components to v1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
-        "@gisce/react-formiga-components": "1.12.0",
+        "@gisce/react-formiga-components": "1.12.1",
         "@gisce/react-formiga-table": "1.13.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3397,9 +3397,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.12.0.tgz",
-      "integrity": "sha512-66lY9/+kBtky0IJpMvO/+od0jAAEuNNEiLctkGt27aUg9cvEqEzvMyr1df34L0PM5GrnhDjBbCrbh+NyMN3SbA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.12.1.tgz",
+      "integrity": "sha512-8cD0llOUTpqH//qUswf7KeP9rtjv6UNxgzQO0D564TzbaYh5GNV2zHmjBRNDASFOO1G2P3eB7kcw1LcHMvL8xg==",
       "dependencies": {
         "antd": "5.13.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
-    "@gisce/react-formiga-components": "1.12.0",
+    "@gisce/react-formiga-components": "1.12.1",
     "@gisce/react-formiga-table": "1.13.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.12.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.12.1).