### PR TITLE
update gisce/react-formiga-components to v1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
-        "@gisce/react-formiga-components": "1.12.1",
+        "@gisce/react-formiga-components": "1.13.0",
         "@gisce/react-formiga-table": "1.13.2",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -155,13 +155,13 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.2.6.tgz",
-      "integrity": "sha512-4wn0WShF43TrggskBJPRqCD0fcHbzTYjnaoskdiJrVHg86yxoZ8ZUqsXvyn4WUqehRiFKnaclOhqk9w4Ui2KVw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
+      "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
-        "@ant-design/icons-svg": "^4.3.0",
-        "@babel/runtime": "^7.11.2",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@babel/runtime": "^7.24.8",
         "classnames": "^2.2.6",
         "rc-util": "^5.31.1"
       },
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@ant-design/icons-svg": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
-      "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA=="
     },
     "node_modules/@ant-design/plots": {
       "version": "1.2.5",
@@ -3397,10 +3397,12 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.12.1.tgz",
-      "integrity": "sha512-8cD0llOUTpqH//qUswf7KeP9rtjv6UNxgzQO0D564TzbaYh5GNV2zHmjBRNDASFOO1G2P3eB7kcw1LcHMvL8xg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.13.0.tgz",
+      "integrity": "sha512-S93TN+3C+vAGZ/KO9454LUHskxG6BGsEKmL7kNgS2FpdFd+zPLddXpL4jtfBRjG8grzUv3qcYIfnE7VCpdiZBQ==",
       "dependencies": {
+        "@ant-design/icons": "^5.6.1",
+        "@tabler/icons-react": "^3.30.0",
         "antd": "5.13.1",
         "classnames": "^2.5.1",
         "dompurify": "^3.0.11",
@@ -3409,6 +3411,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5",
+        "use-deep-compare": "^1.2.1",
         "use-deep-compare-effect": "^1.8.1",
         "validator": "^13.6.0"
       },
@@ -3419,6 +3422,30 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5"
+      }
+    },
+    "node_modules/@gisce/react-formiga-components/node_modules/@tabler/icons": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.31.0.tgz",
+      "integrity": "sha512-dblAdeKY3+GA1U+Q9eziZ0ooVlZMHsE8dqP0RkwvRtEsAULoKOYaCUOcJ4oW1DjWegdxk++UAt2SlQVnmeHv+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@gisce/react-formiga-components/node_modules/@tabler/icons-react": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.31.0.tgz",
+      "integrity": "sha512-2rrCM5y/VnaVKnORpDdAua9SEGuJKVqPtWxeQ/vUVsgaUx30LDgBZph7/lterXxDY1IKR6NO//HDhWiifXTi3w==",
+      "dependencies": {
+        "@tabler/icons": "3.31.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@gisce/react-formiga-table": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
-    "@gisce/react-formiga-components": "1.12.1",
+    "@gisce/react-formiga-components": "1.13.0",
     "@gisce/react-formiga-table": "1.13.2",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.13.0](https://github.com/gisce/react-formiga-components/releases/tag/v1.13.0).