### PR TITLE
update gisce/react-formiga-components to v1.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
-        "@gisce/react-formiga-components": "1.13.0",
+        "@gisce/react-formiga-components": "1.13.1",
         "@gisce/react-formiga-table": "1.13.2",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3396,12 +3396,10 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.13.0.tgz",
-      "integrity": "sha512-S93TN+3C+vAGZ/KO9454LUHskxG6BGsEKmL7kNgS2FpdFd+zPLddXpL4jtfBRjG8grzUv3qcYIfnE7VCpdiZBQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.13.1.tgz",
+      "integrity": "sha512-rHTeArCtYxH14EBcCxk+++JFI7m+mDklg+LRzK+382iDKs2dn0S9XGLS6KEEdXfjA7mZrdRXkzyje1vmy22raw==",
       "dependencies": {
-        "@ant-design/icons": "^5.6.1",
-        "@tabler/icons-react": "^3.30.0",
         "antd": "5.13.1",
         "classnames": "^2.5.1",
         "dompurify": "^3.0.11",
@@ -3410,7 +3408,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5",
-        "use-deep-compare": "^1.2.1",
         "use-deep-compare-effect": "^1.8.1",
         "validator": "^13.6.0"
       },
@@ -3421,30 +3418,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5"
-      }
-    },
-    "node_modules/@gisce/react-formiga-components/node_modules/@tabler/icons": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.31.0.tgz",
-      "integrity": "sha512-dblAdeKY3+GA1U+Q9eziZ0ooVlZMHsE8dqP0RkwvRtEsAULoKOYaCUOcJ4oW1DjWegdxk++UAt2SlQVnmeHv+g==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      }
-    },
-    "node_modules/@gisce/react-formiga-components/node_modules/@tabler/icons-react": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.31.0.tgz",
-      "integrity": "sha512-2rrCM5y/VnaVKnORpDdAua9SEGuJKVqPtWxeQ/vUVsgaUx30LDgBZph7/lterXxDY1IKR6NO//HDhWiifXTi3w==",
-      "dependencies": {
-        "@tabler/icons": "3.31.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      },
-      "peerDependencies": {
-        "react": ">= 16"
       }
     },
     "node_modules/@gisce/react-formiga-table": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
-    "@gisce/react-formiga-components": "1.13.0",
+    "@gisce/react-formiga-components": "1.13.1",
     "@gisce/react-formiga-table": "1.13.2",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.13.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.13.1).