### PR TITLE
update gisce/react-formiga-table to v1.14.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "v1.14.0-alpha.1",
-        "@gisce/react-formiga-table": "1.14.0-alpha.2",
+        "@gisce/react-formiga-table": "1.14.0-alpha.3",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.14.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-alpha.2.tgz",
-      "integrity": "sha512-5mqcpngy5Vo71UUm1tCU9Ny8Zkjgu8cHtzjeI5kliE+e4+OL8BR8yBlgNaVo+aga4TzC5RUj1qx7eUiaL3qW1A==",
+      "version": "1.14.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-alpha.3.tgz",
+      "integrity": "sha512-rF9dK4eJ4gE+engiD70s+DBcuTWbMsAeMHDAExI5i2bpQl7hymbkZeAputsZ0kRE+m01avxnK5vF9vcYaItb/Q==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "v1.14.0-alpha.1",
-    "@gisce/react-formiga-table": "1.14.0-alpha.2",
+    "@gisce/react-formiga-table": "1.14.0-alpha.3",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.14.0-alpha.3](https://github.com/gisce/react-formiga-table/releases/tag/v1.14.0-alpha.3).