### PR TITLE
update gisce/react-formiga-table to v1.14.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
         "@gisce/react-formiga-components": "1.14.0",
-        "@gisce/react-formiga-table": "1.13.3",
+        "@gisce/react-formiga-table": "1.14.0-rc.2",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.13.3.tgz",
-      "integrity": "sha512-+pn00E2/SD6BE1QUKsxQHvKZata4apUP5UTuean/AgB8qsX9qfsA9J86rj+CmDYhDax9tJuhMZqqlmfF/lGOkg==",
+      "version": "1.14.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-rc.2.tgz",
+      "integrity": "sha512-5iP8GwXNRqTWXiI57c4oSoiQqghShAHrzBYNU+X/dKPmzKnuu5zeltchiTgSltE04W8Hf8nXMOzxZjtSkvZ3RA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
     "@gisce/react-formiga-components": "1.14.0",
-    "@gisce/react-formiga-table": "1.13.3",
+    "@gisce/react-formiga-table": "1.14.0-rc.2",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.14.0-rc.2](https://github.com/gisce/react-formiga-table/releases/tag/v1.14.0-rc.2).