### PR TITLE
update gisce/react-formiga-table to v1.14.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
         "@gisce/react-formiga-components": "1.15.0-alpha.1",
-        "@gisce/react-formiga-table": "1.14.0-alpha.5",
+        "@gisce/react-formiga-table": "1.14.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.24.9",
@@ -3486,9 +3486,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.14.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-alpha.5.tgz",
-      "integrity": "sha512-YoIJoDxH4w4CuoNNOtOGDioXzAFMaZG/jc0+raAHg4azoRNQT3kMc0qq3snkM2oc+ienlgo7ZPzrLM6Ga2W4aA==",
+      "version": "1.14.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-alpha.6.tgz",
+      "integrity": "sha512-ZsQX3geLryYwZkJdoXjosN44OnHyXvw/NZQl9i1bTHZbYEHaMp1bcxE+QHCEmIzuy6pmdOjkBwRz26PcFxKZPQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
     "@gisce/react-formiga-components": "1.15.0-alpha.1",
-    "@gisce/react-formiga-table": "1.14.0-alpha.5",
+    "@gisce/react-formiga-table": "1.14.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.24.9",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.14.0-alpha.6](https://github.com/gisce/react-formiga-table/releases/tag/v1.14.0-alpha.6).