### PR TITLE
update gisce/react-formiga-table to v1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0",
         "@gisce/react-formiga-components": "1.14.0",
-        "@gisce/react-formiga-table": "1.13.4",
+        "@gisce/react-formiga-table": "1.14.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
         "@types/deep-equal": "^1.0.4",
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.13.4.tgz",
-      "integrity": "sha512-H7xmei5n1o0A5EAnq0AQ4jKW6vORLGgAJ85B/NqKqswcCLy0AS4cY3x2WM2tlLvjRh+F0HSYoQrs++S3b7I2oQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0.tgz",
+      "integrity": "sha512-PMRpJsigz7zmfjtAKxjhtQ8Dfpamw4sJVTQtUHs2cXi4Qr0w/zwCsmLatoLEHeIMMfFH+nlmOJBGciw7DhT1XQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0",
     "@gisce/react-formiga-components": "1.14.0",
-    "@gisce/react-formiga-table": "1.13.4",
+    "@gisce/react-formiga-table": "1.14.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.14.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.14.0).