### PR TITLE
update gisce/react-formiga-components to v1.15.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.0-alpha.3",
-        "@gisce/react-formiga-components": "1.15.0-alpha.2",
+        "@gisce/react-formiga-components": "1.15.0-alpha.3",
         "@gisce/react-formiga-table": "1.14.0-alpha.9",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -3401,13 +3401,13 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.15.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.0-alpha.2.tgz",
-      "integrity": "sha512-u1a2oNTxP3k6qocb0NmUfcUTqz2r0vti+wa28kNl2Bzl0nDqh77Mtg//5Z5W7FY33MzcVHG0cyyT+yfx1Rv7lw==",
+      "version": "1.15.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.0-alpha.3.tgz",
+      "integrity": "sha512-/v0ubXDZE7lQ9ftdxt6QfAaph5vPC536YwLnKYxByWubROjeCIvEFQaazbh6WvajHrfpq7tkY5XSOHJG3OwfCw==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",
-        "antd": "5.25.0",
+        "antd": "5.25.1",
         "classnames": "^2.5.1",
         "dompurify": "^3.0.11",
         "file-type-buffer-browser": "git+ssh://git@github.com/mguellsegarra/file-type-buffer-browser.git",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.0-alpha.3",
-    "@gisce/react-formiga-components": "1.15.0-alpha.2",
+    "@gisce/react-formiga-components": "1.15.0-alpha.3",
     "@gisce/react-formiga-table": "1.14.0-alpha.9",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.15.0-alpha.3](https://github.com/gisce/react-formiga-components/releases/tag/v1.15.0-alpha.3).