### PR TITLE
update gisce/ooui to v2.31.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.31.0-alpha.1",
+        "@gisce/ooui": "2.31.0-alpha.2",
         "@gisce/react-formiga-components": "1.15.0-alpha.3",
         "@gisce/react-formiga-table": "1.14.0-alpha.9",
         "@monaco-editor/react": "^4.4.5",
@@ -3387,9 +3387,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.31.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0-alpha.1.tgz",
-      "integrity": "sha512-azvRzL/Z+1dfbxfMBtJ2NlLMf3HBss4L2ouDX8n27/IuknOZ8mwDF6URINQtW7ilTbLc9E3C/MyTFzmOAmtPmg==",
+      "version": "2.31.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0-alpha.2.tgz",
+      "integrity": "sha512-UevuL2oz4R7griZ+XlvoiCSZZHuPHLtCUhfpv/m7FRFqiaYZeB2pF0hrNycBNFrga5ha7/8UF+naKd+R7R627Q==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.31.0-alpha.1",
+    "@gisce/ooui": "2.31.0-alpha.2",
     "@gisce/react-formiga-components": "1.15.0-alpha.3",
     "@gisce/react-formiga-table": "1.14.0-alpha.9",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.31.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.31.0-alpha.2).