### PR TITLE
update gisce/react-formiga-components to v1.15.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.31.0-alpha.2",
-        "@gisce/react-formiga-components": "1.15.0-alpha.3",
+        "@gisce/react-formiga-components": "1.15.0-alpha.4",
         "@gisce/react-formiga-table": "1.14.0-alpha.9",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -3403,9 +3403,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.15.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.0-alpha.3.tgz",
-      "integrity": "sha512-/v0ubXDZE7lQ9ftdxt6QfAaph5vPC536YwLnKYxByWubROjeCIvEFQaazbh6WvajHrfpq7tkY5XSOHJG3OwfCw==",
+      "version": "1.15.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.0-alpha.4.tgz",
+      "integrity": "sha512-ivFrZgTSIwMojU8453siF+3T1MZU3LL+M2AK8Q7AbtE+DoZ/0eMZN/hV2rFetYZl2B0qE0Ysi9wD4Z0miYRBJw==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.31.0-alpha.2",
-    "@gisce/react-formiga-components": "1.15.0-alpha.3",
+    "@gisce/react-formiga-components": "1.15.0-alpha.4",
     "@gisce/react-formiga-table": "1.14.0-alpha.9",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.15.0-alpha.4](https://github.com/gisce/react-formiga-components/releases/tag/v1.15.0-alpha.4).