### PR TITLE
update gisce/react-formiga-table to v1.15.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.31.0-alpha.2",
         "@gisce/react-formiga-components": "1.15.0-alpha.4",
-        "@gisce/react-formiga-table": "1.14.0-alpha.9",
+        "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.14.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.14.0-alpha.9.tgz",
-      "integrity": "sha512-pKfbYZugdiv+7f2X4pOS8Gk6L2Ck3Dw8ypDRe1QRR2q12yA/InOPEwRcZOo9asm0QwqemoynQXrzOop4Pkn/uQ==",
+      "version": "1.15.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.15.0-alpha.1.tgz",
+      "integrity": "sha512-kOiFJ2WC6yi8wTYCvfnLdd2hatXJSpU6yhIC1bxMp2edgk3Si9JveyClCD8iJ9uHc2FzNUNVMUKjsxGHpNQYTQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.31.0-alpha.2",
     "@gisce/react-formiga-components": "1.15.0-alpha.4",
-    "@gisce/react-formiga-table": "1.14.0-alpha.9",
+    "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.15.0-alpha.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.15.0-alpha.1).