### PR TITLE
update gisce/react-formiga-components to v1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.1",
-        "@gisce/react-formiga-components": "1.14.0",
+        "@gisce/react-formiga-components": "1.15.0",
         "@gisce/react-formiga-table": "1.14.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.14.0.tgz",
-      "integrity": "sha512-9MUnou9ctckAwU+RPtW1o4jqaYZG3kb/G/CvsGlNdTB+5lfL1zDbQIdjavUP27GvLM1xg7wDsVnuW/OHxGhJIQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.0.tgz",
+      "integrity": "sha512-C+k3/j1lHxgWWe+toGEYk/6Ovsqy3MUImWs9KwimkogkMTnjNXeivyIoW8sW+6N1Bk6OSSutQSQ6opXrJY9smw==",
       "dependencies": {
         "@ant-design/icons": "^5.6.1",
         "@tabler/icons-react": "^3.30.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.1",
-    "@gisce/react-formiga-components": "1.14.0",
+    "@gisce/react-formiga-components": "1.15.0",
     "@gisce/react-formiga-table": "1.14.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.15.0](https://github.com/gisce/react-formiga-components/releases/tag/v1.15.0).