### PR TITLE
update gisce/react-formiga-components to v1.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.1",
-        "@gisce/react-formiga-components": "1.15.1",
+        "@gisce/react-formiga-components": "1.15.2",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
         "@tabler/icons-react": "^2.11.0",
@@ -3398,13 +3398,13 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.1.tgz",
-      "integrity": "sha512-Hw+6Z4jp9un3bW7oxPTSli9r3NbElJSUJttVORfqp5tFRKSa3QTx+DGT5L8G348/78gUBJRHzAsGGmHb7cFGSQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.2.tgz",
+      "integrity": "sha512-fdfoYjQ0bJOXruB38E+ib8m2WGVT9n/wKwhC4FdJUskqGDzjgDLVj3DJg5Za8ozRIRA9vq9r4lXiHldv8GuMKw==",
       "dependencies": {
-        "@ant-design/icons": "^5.6.1",
-        "@tabler/icons-react": "^3.30.0",
-        "antd": "5.13.1",
+        "@ant-design/icons": "^6.0.0",
+        "@tabler/icons-react": "^3.31.0",
+        "antd": "5.25.1",
         "classnames": "^2.5.1",
         "dompurify": "^3.0.11",
         "file-type-buffer-browser": "git+ssh://git@github.com/mguellsegarra/file-type-buffer-browser.git",
@@ -3422,6 +3422,40 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "5.3.5"
+      }
+    },
+    "node_modules/@gisce/react-formiga-components/node_modules/@ant-design/colors": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.0.tgz",
+      "integrity": "sha512-6YzkKCw30EI/E9kHOIXsQDHmMvTllT8STzjMb4K2qzit33RW2pqCJP0sk+hidBntXxE+Vz4n1+RvCTfBw6OErw==",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.0"
+      }
+    },
+    "node_modules/@gisce/react-formiga-components/node_modules/@ant-design/fast-color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.0.tgz",
+      "integrity": "sha512-eqvpP7xEDm2S7dUzl5srEQCBTXZMmY3ekf97zI+M2DHOYyKdJGH0qua0JACHTqbkRnD/KHFQP9J1uMJ/XWVzzA==",
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@gisce/react-formiga-components/node_modules/@ant-design/icons": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.0.0.tgz",
+      "integrity": "sha512-o0aCCAlHc1o4CQcapAwWzHeaW2x9F49g7P3IDtvtNXgHowtRWYb7kiubt8sQPFvfVIVU/jLw2hzeSlNt0FU+Uw==",
+      "dependencies": {
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.2.1",
+        "classnames": "^2.2.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/@gisce/react-formiga-components/node_modules/@tabler/icons": {
@@ -5165,6 +5199,23 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.2.1.tgz",
+      "integrity": "sha512-AUVu6jO+lWjQnUOOECwu8iR0EdElQgWW5NBv5vP/Uf9dWbAX3udhMutRlkVXjuac2E40ghkFy+ve00mc/3Fymg==",
+      "dependencies": {
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.1",
-    "@gisce/react-formiga-components": "1.15.1",
+    "@gisce/react-formiga-components": "1.15.2",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",
     "@tabler/icons-react": "^2.11.0",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.15.2](https://github.com/gisce/react-formiga-components/releases/tag/v1.15.2).