### PR TITLE
update gisce/react-formiga-components to v1.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.30.1",
-        "@gisce/react-formiga-components": "1.15.2",
+        "@gisce/react-formiga-components": "1.15.3",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -3403,9 +3403,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.2.tgz",
-      "integrity": "sha512-fdfoYjQ0bJOXruB38E+ib8m2WGVT9n/wKwhC4FdJUskqGDzjgDLVj3DJg5Za8ozRIRA9vq9r4lXiHldv8GuMKw==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.3.tgz",
+      "integrity": "sha512-7LG3suFaQNaa4cSxr8iJikISmaWhyIdzHJ4a2nJHQby7lLrrs7jkGnmpGUeQaXLU8u99pZrt/ZiYPHmVMpPXLA==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.30.1",
-    "@gisce/react-formiga-components": "1.15.2",
+    "@gisce/react-formiga-components": "1.15.3",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.15.3](https://github.com/gisce/react-formiga-components/releases/tag/v1.15.3).