### PR TITLE
Allow to customize buttons in the many2one field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.30.1",
+        "@gisce/ooui": "2.31.0",
         "@gisce/react-formiga-components": "1.15.3",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3389,9 +3389,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.30.1.tgz",
-      "integrity": "sha512-uGLhn/XjWNnlsONXT27gHUFf0ci8IX123AY5ggQalb+Q3dVCzRmP0zLvObzEB3CCaaDPfs58mx7QInlodDVTVg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0.tgz",
+      "integrity": "sha512-2NbrI6tWFjy0y6i8R3lA9v3l8vHPb05K+13XJaQDyVkWoo0g+hfn+q2XH632JhSm9vHAKq14nzfQgofPPDdPJw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.30.1",
+    "@gisce/ooui": "2.31.0",
     "@gisce/react-formiga-components": "1.15.3",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/base/many2one/Many2one.tsx
+++ b/src/widgets/base/many2one/Many2one.tsx
@@ -281,7 +281,11 @@ export const Many2oneInput: React.FC<Many2oneInputProps> = (
             onClick={() => {
               setShowFormModal(true);
             }}
-            style={{ borderRadius: 0 }}
+            style={
+              ooui.showSearch
+                ? { borderRadius: 0 }
+                : { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }
+            }
             tabIndex={-1}
           />
         </Col>

--- a/src/widgets/base/many2one/Many2one.tsx
+++ b/src/widgets/base/many2one/Many2one.tsx
@@ -267,17 +267,21 @@ export const Many2oneInput: React.FC<Many2oneInputProps> = (
           }
         />
       </Col>
-      <Col flex="none" style={{ paddingRight: 0, paddingLeft: 0 }}>
-        <Button
-          icon={<FolderOpenOutlined />}
-          disabled={id === undefined || text === "" || inputText === undefined}
-          onClick={() => {
-            setShowFormModal(true);
-          }}
-          style={{ borderRadius: 0 }}
-          tabIndex={-1}
-        />
-      </Col>
+      {ooui.showFolder && (
+        <Col flex="none" style={{ paddingRight: 0, paddingLeft: 0 }}>
+          <Button
+            icon={<FolderOpenOutlined />}
+            disabled={
+              id === undefined || text === "" || inputText === undefined
+            }
+            onClick={() => {
+              setShowFormModal(true);
+            }}
+            style={{ borderRadius: 0 }}
+            tabIndex={-1}
+          />
+        </Col>
+      )}
       <Col flex="none" style={{ paddingLeft: 0 }}>
         <Button
           icon={searching ? <LoadingOutlined /> : <SearchOutlined />}

--- a/src/widgets/base/many2one/Many2one.tsx
+++ b/src/widgets/base/many2one/Many2one.tsx
@@ -254,16 +254,20 @@ export const Many2oneInput: React.FC<Many2oneInputProps> = (
           onChange={onValueStringChange}
           style={{
             ...requiredStyle,
-            ...{ borderTopRightRadius: 0, borderBottomRightRadius: 0 },
+            ...(ooui.showSearch || ooui.showFolder
+              ? { borderTopRightRadius: 0, borderBottomRightRadius: 0 }
+              : {}),
           }}
           onBlur={onElementLostFocus}
           onKeyDown={onKeyDown}
           suffix={
-            <Many2oneSuffix
-              id={id}
-              model={relation}
-              context={{ ...getContext?.(), ...context }}
-            />
+            ooui.showMenu && (
+              <Many2oneSuffix
+                id={id}
+                model={relation}
+                context={{ ...getContext?.(), ...context }}
+              />
+            )
           }
         />
       </Col>
@@ -282,18 +286,20 @@ export const Many2oneInput: React.FC<Many2oneInputProps> = (
           />
         </Col>
       )}
-      <Col flex="none" style={{ paddingLeft: 0 }}>
-        <Button
-          icon={searching ? <LoadingOutlined /> : <SearchOutlined />}
-          disabled={readOnly || searching}
-          onClick={() => {
-            searchButtonTappedRef.current = true;
-            tryFetchFirstResultOrShowSearch(text);
-          }}
-          style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
-          tabIndex={-1}
-        />
-      </Col>
+      {ooui.showSearch && (
+        <Col flex="none" style={{ paddingLeft: 0 }}>
+          <Button
+            icon={searching ? <LoadingOutlined /> : <SearchOutlined />}
+            disabled={readOnly || searching}
+            onClick={() => {
+              searchButtonTappedRef.current = true;
+              tryFetchFirstResultOrShowSearch(text);
+            }}
+            style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
+            tabIndex={-1}
+          />
+        </Col>
+      )}
       <SearchModal
         model={relation}
         domain={searchDomain}

--- a/src/widgets/base/many2one/Many2oneTree.tsx
+++ b/src/widgets/base/many2one/Many2oneTree.tsx
@@ -1,18 +1,21 @@
 import { Space } from "antd";
 import React from "react";
+import { Many2one as Many2oneOoui } from "@gisce/ooui";
 import { Many2oneSuffix } from "./Many2oneSuffix";
 
-export type Many2oneTreeProps = { m2oField: any };
+export type Many2oneTreeProps = { m2oField: any; ooui: Many2oneOoui };
 
 export const Many2oneTree = (props: Many2oneTreeProps): React.ReactElement => {
-  const { m2oField } = props;
+  const { m2oField, ooui } = props;
   if (!m2oField) {
     return <></>;
   }
   return (
     <Space>
       <>{m2oField.value}</>
-      <Many2oneSuffix id={m2oField.id} model={m2oField.model} />
+      {ooui.showMenu && (
+        <Many2oneSuffix id={m2oField.id} model={m2oField.model} />
+      )}
     </Space>
   );
 };

--- a/src/widgets/views/Tree/treeComponents.tsx
+++ b/src/widgets/views/Tree/treeComponents.tsx
@@ -55,7 +55,7 @@ export const Many2OneComponent = ({
   value: any;
   ooui: Many2oneOoui;
 }): ReactElement => {
-  return useMemo(() => <Many2oneTree m2oField={value} ooui={ooui} />, [value]);
+  return useMemo(() => <Many2oneTree m2oField={value} ooui={ooui} />, [value, ooui]);
 };
 
 export const TextComponent = ({ value }: { value: any }): ReactElement => {

--- a/src/widgets/views/Tree/treeComponents.tsx
+++ b/src/widgets/views/Tree/treeComponents.tsx
@@ -13,7 +13,7 @@ import ConnectionProvider from "@/ConnectionProvider";
 import { colorFromString } from "@/helpers/formHelper";
 import { EmailTagsRender } from "@/widgets/custom/EmailTags";
 import { ImageRender } from "@/widgets/base/Image";
-import { Char as CharOOui } from "@gisce/ooui";
+import { Char as CharOOui , Many2one as Many2oneOoui } from "@gisce/ooui";
 import { DatePickerConfig } from "@/common/DatePicker.helpers";
 import { useActionViewContext } from "@/context/ActionViewContext";
 import { useOne2manyContext } from "@/context/One2manyContext";
@@ -48,8 +48,14 @@ export const EmailTagsComponent = ({
   return useMemo(() => <EmailTagsRender emails={value} />, [value]);
 };
 
-export const Many2OneComponent = ({ value }: { value: any }): ReactElement => {
-  return useMemo(() => <Many2oneTree m2oField={value} />, [value]);
+export const Many2OneComponent = ({
+  value,
+  ooui,
+}: {
+  value: any;
+  ooui: Many2oneOoui;
+}): ReactElement => {
+  return useMemo(() => <Many2oneTree m2oField={value} ooui={ooui} />, [value]);
 };
 
 export const TextComponent = ({ value }: { value: any }): ReactElement => {


### PR DESCRIPTION
This pull request introduces a conditional rendering feature for the folder button in the `Many2oneInput` component. The most important change ensures that the folder button is only displayed when the `ooui.showFolder` property is true.

### Enhancements to conditional rendering:

* [`src/widgets/base/many2one/Many2one.tsx`](diffhunk://#diff-d233f22fa640d6434372981e7a941e9bb0a08ca04cac0e8018359ab74ad22c3bR270-R284): Wrapped the folder button in a conditional block to render it only if `ooui.showFolder` is true, improving the component's flexibility and alignment with the `ooui` configuration.

### Related
- Needs https://github.com/gisce/ooui/pull/184
- Closes https://github.com/gisce/webclient/issues/2177