### PR TITLE
update gisce/ooui to v2.31.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.31.0-alpha.2",
+        "@gisce/ooui": "2.31.0-alpha.3",
         "@gisce/react-formiga-components": "1.16.0-alpha.1",
         "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3389,9 +3389,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.31.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0-alpha.2.tgz",
-      "integrity": "sha512-UevuL2oz4R7griZ+XlvoiCSZZHuPHLtCUhfpv/m7FRFqiaYZeB2pF0hrNycBNFrga5ha7/8UF+naKd+R7R627Q==",
+      "version": "2.31.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0-alpha.3.tgz",
+      "integrity": "sha512-npowFTeRproICXyYD6o4d0B0lnKRCnhHG3IFyqYGAFKy3Tqc+2w3X1MzUS5V6rDLeUKqFi/vJzmAXDho1aTlhA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.31.0-alpha.2",
+    "@gisce/ooui": "2.31.0-alpha.3",
     "@gisce/react-formiga-components": "1.16.0-alpha.1",
     "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.31.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.31.0-alpha.3).