### PR TITLE
update gisce/ooui to v2.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.30.1",
+        "@gisce/ooui": "2.31.0",
         "@gisce/react-formiga-components": "1.15.3",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -3389,9 +3389,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.30.1.tgz",
-      "integrity": "sha512-uGLhn/XjWNnlsONXT27gHUFf0ci8IX123AY5ggQalb+Q3dVCzRmP0zLvObzEB3CCaaDPfs58mx7QInlodDVTVg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0.tgz",
+      "integrity": "sha512-2NbrI6tWFjy0y6i8R3lA9v3l8vHPb05K+13XJaQDyVkWoo0g+hfn+q2XH632JhSm9vHAKq14nzfQgofPPDdPJw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.30.1",
+    "@gisce/ooui": "2.31.0",
     "@gisce/react-formiga-components": "1.15.3",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.31.0](https://github.com/gisce/ooui/releases/tag/v2.31.0).