### PR TITLE
update gisce/ooui to v2.32.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.31.0-alpha.4",
+        "@gisce/ooui": "2.32.0-alpha.1",
         "@gisce/react-formiga-components": "1.16.0-alpha.1",
         "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
@@ -3389,9 +3389,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.31.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.31.0-alpha.4.tgz",
-      "integrity": "sha512-nfY+G7UDC4saEmKDEvxOljTxyLPA+x111UnK9lrbrPmrR4rHVAXjGSeI5jxbpXTJ9GX/5uSYMYi/2AEXgwg11w==",
+      "version": "2.32.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.32.0-alpha.1.tgz",
+      "integrity": "sha512-lZ6pKXj9LcyI+xaLySabgBpAPkN69kirYIn8ewmt8Z2OmxL5illwBw2scEHnmdtZzcGjhcByfxrqNXuXPE8VmA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.31.0-alpha.4",
+    "@gisce/ooui": "2.32.0-alpha.1",
     "@gisce/react-formiga-components": "1.16.0-alpha.1",
     "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.32.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.32.0-alpha.1).