### PR TITLE
update gisce/react-formiga-components to v1.16.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.32.0-alpha.2",
-        "@gisce/react-formiga-components": "1.16.0-alpha.1",
+        "@gisce/react-formiga-components": "1.16.0-alpha.2",
         "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.16.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.16.0-alpha.1.tgz",
-      "integrity": "sha512-TkNdP5K62BW/eG+6f5AnA3Bw3tdWrT/lxDwu3taLfSwETn7pL6VtuxzaPw5KK8TAGG2+t96PLy5ct15ri8aUuA==",
+      "version": "1.16.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.16.0-alpha.2.tgz",
+      "integrity": "sha512-lMcXVI9DndGHJ3CMLPl1f57JgFil7ny/qzbHowzvkryi8pT7g4nykcQato6DmjY4GRO0lLPVOM6l+4snX2jNbw==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.32.0-alpha.2",
-    "@gisce/react-formiga-components": "1.16.0-alpha.1",
+    "@gisce/react-formiga-components": "1.16.0-alpha.2",
     "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.16.0-alpha.2](https://github.com/gisce/react-formiga-components/releases/tag/v1.16.0-alpha.2).