### PR TITLE
update gisce/react-formiga-components to v1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.32.0",
-        "@gisce/react-formiga-components": "1.15.4",
+        "@gisce/react-formiga-components": "1.16.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.15.4.tgz",
-      "integrity": "sha512-Qlp+SdzB2tlFrA4aWC+Xb1jHQJrhr2m296ESXN4V0qTS85THDxvXQzLni+TKorExgsaIIEHLlnAman+CJujT0w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.16.0.tgz",
+      "integrity": "sha512-fHocy7JqLc2R8+dUYOdrJ1HXZMVNAGsY/DeSNK598sPZPcSoQsnd4AHTIwmqwgccgh1ixbXpz6HFnXqcPbQb/Q==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.32.0",
-    "@gisce/react-formiga-components": "1.15.4",
+    "@gisce/react-formiga-components": "1.16.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.16.0](https://github.com/gisce/react-formiga-components/releases/tag/v1.16.0).