### PR TITLE
update gisce/ooui to v2.33.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.32.0-alpha.2",
+        "@gisce/ooui": "2.33.0-alpha.1",
         "@gisce/react-formiga-components": "1.16.0-alpha.3",
         "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
@@ -2158,9 +2158,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.32.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.32.0-alpha.2.tgz",
-      "integrity": "sha512-b7Dyv1g0VU98qk9mGaFmh2ft9zetV431mThYAwtjCL5pR03UElKXP4pmUVCsZPidFKwuY1wt7UfiM4WlmzT9qg==",
+      "version": "2.33.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.1.tgz",
+      "integrity": "sha512-8qFHoGoyiCLyXg1/vKs8WvB5H+mzNW5ecqmVmppp1vpk1vi/64QIRiaxCOMYEZt6yNGFwxp6cwPN9/mrCcjKRg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.32.0-alpha.2",
+    "@gisce/ooui": "2.33.0-alpha.1",
     "@gisce/react-formiga-components": "1.16.0-alpha.3",
     "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.33.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.33.0-alpha.1).