### PR TITLE
update gisce/react-formiga-components to v1.17.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.33.0-alpha.1",
-        "@gisce/react-formiga-components": "1.17.0-alpha.1",
+        "@gisce/react-formiga-components": "1.17.0-alpha.2",
         "@gisce/react-formiga-table": "1.15.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.17.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0-alpha.1.tgz",
-      "integrity": "sha512-OKaxGcXRk499dnUEgjbnoOYNievQ1H7uL3JL/padg8nYonUJdQK3RedWPGxAzuN08vWv+xI8Rr2IY8E8vezjXA==",
+      "version": "1.17.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0-alpha.2.tgz",
+      "integrity": "sha512-kxRiTvqKy9gklDCAooEAxz+WlUS3iLatheOTtnb1OwSb6VwwMrI0hdAkS7et7zU+nPCVwAU1zOiL1gc/wzlhlQ==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.33.0-alpha.1",
-    "@gisce/react-formiga-components": "1.17.0-alpha.1",
+    "@gisce/react-formiga-components": "1.17.0-alpha.2",
     "@gisce/react-formiga-table": "1.15.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.17.0-alpha.2](https://github.com/gisce/react-formiga-components/releases/tag/v1.17.0-alpha.2).