### PR TITLE
update gisce/ooui to v2.33.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.32.1",
+        "@gisce/ooui": "2.33.0-alpha.2",
         "@gisce/react-formiga-components": "1.17.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -39,7 +39,6 @@
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
         "@gisce/commitlint-rules": "1.0.5",
-        "@playwright/test": "^1.53.0",
         "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "10.0.4",
@@ -71,7 +70,6 @@
         "eslint-plugin-react-hooks": "4.6.0",
         "husky": "8.0.3",
         "lint-staged": "13.2.3",
-        "playwright": "^1.53.0",
         "prettier": "3.0.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "semantic-release": "21.0.7",
@@ -2147,9 +2145,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.32.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.32.1.tgz",
-      "integrity": "sha512-6GeFuZ+cM7H3DjishMD8i0abFJg5uT2V7xYTIRQOxSfQX3Vt+87hJ21BeR4eHlWs3xvC5kmeuXADiLqNO0t0iQ==",
+      "version": "2.33.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.2.tgz",
+      "integrity": "sha512-mHGBO+Ug5wIqAebTgiQov55BcN3RGMr774ZDL7q3ZNBDfaSJcUbNYQQbVol9tp3PvnTi5B8Vp5rZGLEjmqRoFA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",
@@ -2692,21 +2690,6 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^19.0.0"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
-      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.53.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -15338,50 +15321,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
-      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.53.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
-      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.32.1",
+    "@gisce/ooui": "2.33.0-alpha.2",
     "@gisce/react-formiga-components": "1.17.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.33.0-alpha.2](https://github.com/gisce/ooui/releases/tag/v2.33.0-alpha.2).