### PR TITLE
Label: add suport for many2one

### DIFF
--- a/src/widgets/base/Label.tsx
+++ b/src/widgets/base/Label.tsx
@@ -30,7 +30,11 @@ const Label = (props: Props) => {
   let labelTitle = "";
   if (!ooui.fieldForLabel && ooui._id) {
     labelText = formContext.getFieldValue(ooui._id);
-    if (
+    if (ooui.fieldType === "many2one") {
+      labelText = labelText ? labelText[1] : "";
+    } else if (ooui.fieldType === "selection") {
+      labelText = ooui.selectionValues.get(labelText) || "";
+    } else if (
       ooui.fieldType === "date" ||
       ooui.fieldType === "time" ||
       ooui.fieldType === "datetime"


### PR DESCRIPTION
This pull request updates the logic for determining the `labelText` in the `Label` component to handle additional field types (`many2one` and `selection`) and improve its functionality.

Enhancements to field type handling in `Label`:

* [`src/widgets/base/Label.tsx`](diffhunk://#diff-64f1ff350daa57852626b27e94ce64f5626cc46342578dcd1433754616b91cbbL33-R37): Added specific handling for `many2one` and `selection` field types. For `many2one`, the label text now uses the second element of the field value if available; for `selection`, the label text is derived from the `selectionValues` map.