### PR TITLE
feat: hide button if can write in board.board

### DIFF
--- a/src/actionbar/DashboardActionBar.tsx
+++ b/src/actionbar/DashboardActionBar.tsx
@@ -13,38 +13,44 @@ import {
 import { useLocale } from "@gisce/react-formiga-components";
 import { ActionBarSeparator } from "./ActionBarSeparator";
 import { ShareUrlButton } from "./ShareUrlButton";
+import { useActionViewContext } from "@/context/ActionViewContext";
 
 function DashboardActionBar() {
   const { isLoading, dashboardRef, moveItemsEnabled, setMoveItemsEnabled } =
     useContext(DashboardActionContext) as DashboardActionContextType;
+  const { permissions } = useActionViewContext();
   const { t } = useLocale();
 
   return (
     <Space wrap={true}>
-      <ActionButton
-        icon={
-          <BorderOuterOutlined
-            style={{ color: moveItemsEnabled ? "white" : undefined }}
-          />
-        }
-        type={moveItemsEnabled ? "primary" : "default"}
-        tooltip={t("moveDashboard")}
-        disabled={isLoading}
-        loading={false}
-        onClick={() => {
-          setMoveItemsEnabled(!moveItemsEnabled);
-        }}
-      />
+      {permissions?.write && (
+        <ActionButton
+          icon={
+            <BorderOuterOutlined
+              style={{ color: moveItemsEnabled ? "white" : undefined }}
+            />
+          }
+          type={moveItemsEnabled ? "primary" : "default"}
+          tooltip={t("moveDashboard")}
+          disabled={isLoading}
+          loading={false}
+          onClick={() => {
+            setMoveItemsEnabled(!moveItemsEnabled);
+          }}
+        />
+      )}
       <ActionBarSeparator />
-      <ActionButton
-        icon={<SettingOutlined />}
-        tooltip={t("configDashboard")}
-        disabled={isLoading}
-        loading={false}
-        onClick={() => {
-          dashboardRef?.current.configDashboard();
-        }}
-      />
+      {permissions?.write && (
+        <ActionButton
+          icon={<SettingOutlined />}
+          tooltip={t("configDashboard")}
+          disabled={isLoading}
+          loading={false}
+          onClick={() => {
+            dashboardRef?.current.configDashboard();
+          }}
+        />
+      )}
       <ActionButton
         icon={<ReloadOutlined />}
         tooltip={t("refresh")}


### PR DESCRIPTION
This pull request introduces a permissions check to the `DashboardActionBar` component, ensuring that certain actions are only available to users with write permissions. The changes include importing the `useActionViewContext` hook and conditionally rendering specific action buttons based on the `permissions.write` property.

### Permissions-based rendering:

* [`src/actionbar/DashboardActionBar.tsx`](diffhunk://#diff-d525668b82ebbf8370e6605ad8090db75a9a01b3fe69700df8c31bf1f2351125R16-R26): Added an import for `useActionViewContext` to access the `permissions` object.
* [`src/actionbar/DashboardActionBar.tsx`](diffhunk://#diff-d525668b82ebbf8370e6605ad8090db75a9a01b3fe69700df8c31bf1f2351125R41-R43): Updated the `DashboardActionBar` function to conditionally render the "Move Items" and "Config Dashboard" buttons only if `permissions.write` is true. [[1]](diffhunk://#diff-d525668b82ebbf8370e6605ad8090db75a9a01b3fe69700df8c31bf1f2351125R41-R43) [[2]](diffhunk://#diff-d525668b82ebbf8370e6605ad8090db75a9a01b3fe69700df8c31bf1f2351125R53)

- Closes https://github.com/gisce/webclient/issues/2352