### PR TITLE
update gisce/ooui to v2.33.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.33.0-alpha.2",
+        "@gisce/ooui": "2.33.0-alpha.3",
         "@gisce/react-formiga-components": "1.17.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.33.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.2.tgz",
-      "integrity": "sha512-mHGBO+Ug5wIqAebTgiQov55BcN3RGMr774ZDL7q3ZNBDfaSJcUbNYQQbVol9tp3PvnTi5B8Vp5rZGLEjmqRoFA==",
+      "version": "2.33.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.3.tgz",
+      "integrity": "sha512-8tbMzR9yU4hHXnTDrUxzrTxpRft+qn76kCFrwHisaZor+7/0s3DKMosBeteAjJgVNjDxItY2UnQ0gbsJ+tVpeQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.33.0-alpha.2",
+    "@gisce/ooui": "2.33.0-alpha.3",
     "@gisce/react-formiga-components": "1.17.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.33.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.33.0-alpha.3).