### PR TITLE
Fix tree tags component

### DIFF
--- a/src/widgets/custom/Tags.tsx
+++ b/src/widgets/custom/Tags.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { Tags as TagsOoui } from "@gisce/ooui";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
@@ -13,6 +13,7 @@ import {
 } from "@/helpers/formHelper";
 import ConnectionProvider from "@/ConnectionProvider";
 import { CustomTag } from "@/widgets/custom/Tag";
+import { useNetworkRequest } from "@/hooks/useNetworkRequest";
 
 type TagsProps = WidgetProps & {
   ooui: TagsOoui;
@@ -48,6 +49,21 @@ export const TagsInput = (props: TagsInputProps) => {
   const formContext = useContext(FormContext) as FormContextType;
   const { getContext } = formContext || {};
 
+  const [evalDomainRequest, cancelEvalDomainRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().evalDomain,
+  );
+  const [searchRequest, cancelSearchRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().search,
+  );
+
+  useEffect(() => {
+    return () => {
+      cancelEvalDomainRequest();
+      cancelSearchRequest();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useDeepCompareEffect(() => {
     fetchOptions();
   }, [items]);
@@ -66,20 +82,19 @@ export const TagsInput = (props: TagsInputProps) => {
         params = [["id", "in", itemsToShow]];
       }
       if (ooui.domain) {
-        const evaluatedDomain =
-          await ConnectionProvider.getHandler().evalDomain({
-            domain: ooui.domain,
-            values: transformPlainMany2Ones({
-              fields: formContext?.getFields(),
-              values: formContext.getAllHierarchyValues(),
-            }),
+        const evaluatedDomain = await evalDomainRequest({
+          domain: ooui.domain,
+          values: transformPlainMany2Ones({
             fields: formContext?.getFields(),
-            context: formContext.getContext(),
-          });
+            values: formContext.getAllHierarchyValues(),
+          }),
+          fields: formContext?.getFields(),
+          context: formContext.getContext(),
+        });
         params = [...params, ...evaluatedDomain];
       }
 
-      const optionsRead = await ConnectionProvider.getHandler().search({
+      const optionsRead = await searchRequest({
         model: relation,
         params,
         fieldsToRetrieve: [field],

--- a/src/widgets/views/SearchTreeInfinite.tsx
+++ b/src/widgets/views/SearchTreeInfinite.tsx
@@ -54,6 +54,7 @@ import {
 import { CellRenderer } from "./Tree/CellRenderer";
 import { TreeType } from "@/views/actionViews/TreeActionView";
 import { useTableConfiguration } from "@/hooks/useTableConfiguration";
+import { useNetworkRequest } from "@/hooks/useNetworkRequest";
 
 export const HEIGHT_OFFSET = 10;
 export const MAX_ROWS_TO_SELECT = 200;
@@ -112,6 +113,26 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
     elementRef: containerRef,
     offset: HEIGHT_OFFSET,
   });
+
+  // Network request hooks
+  const [searchCountRequest, cancelSearchCountRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().searchCount,
+  );
+  const [searchForTreeRequest, cancelSearchForTreeRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().searchForTree,
+  );
+  const [searchAllIdsRequest, cancelSearchAllIdsRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().searchAllIds,
+  );
+
+  useEffect(() => {
+    return () => {
+      cancelSearchCountRequest();
+      cancelSearchForTreeRequest();
+      cancelSearchAllIdsRequest();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { treeView, formView, loading } = useFetchTreeViews({
     model,
@@ -284,7 +305,7 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
     setTotalRows(undefined);
     setTotalItemsActionView(0);
     try {
-      const totalItems = await ConnectionProvider.getHandler().searchCount({
+      const totalItems = await searchCountRequest({
         params: nameSearch ? domain : mergedParams,
         model,
         context: parentContext,
@@ -305,6 +326,7 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
     parentContext,
     setTotalItemsActionView,
     showErrorNotification,
+    searchCountRequest,
   ]);
 
   const fetchResults = useDeepCompareCallback(
@@ -360,24 +382,23 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
           onHasFunctionFieldsToParseConditions(),
       });
 
-      const { results, attrsEvaluated } =
-        await ConnectionProvider.getHandler().searchForTree({
-          params,
-          limit: endRow - startRow,
-          offset: startRow,
-          model,
-          fields: treeView!.field_parent
-            ? { ...treeView!.fields, [treeView!.field_parent]: {} }
-            : treeView!.fields,
-          context: parentContext,
-          attrs,
-          order,
-          name_search: nameSearch,
-          skipFunctionFields: SHOULD_MAKE_DEFERRED_FUNCTION_READ,
-          onIdsRetrieved: (ids: number[]) => {
-            addRecordsToCheckFunctionFields(ids);
-          },
-        });
+      const { results, attrsEvaluated } = await searchForTreeRequest({
+        params,
+        limit: endRow - startRow,
+        offset: startRow,
+        model,
+        fields: treeView!.field_parent
+          ? { ...treeView!.fields, [treeView!.field_parent]: {} }
+          : treeView!.fields,
+        context: parentContext,
+        attrs,
+        order,
+        name_search: nameSearch,
+        skipFunctionFields: SHOULD_MAKE_DEFERRED_FUNCTION_READ,
+        onIdsRetrieved: (ids: number[]) => {
+          addRecordsToCheckFunctionFields(ids);
+        },
+      });
 
       setSearchQuery?.({
         model,
@@ -436,6 +457,7 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
       onHasFunctionFieldsToParseConditions,
       setNameSearchFetchCompleted,
       updateAttributes,
+      searchForTreeRequest,
     ],
   );
 
@@ -541,14 +563,12 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
         return;
       }
 
-      const allRowsResults = await ConnectionProvider.getHandler().searchAllIds(
-        {
-          params: nameSearch ? domain : mergedParams,
-          model,
-          context: parentContext,
-          totalItems: totalRows,
-        },
-      );
+      const allRowsResults = await searchAllIdsRequest({
+        params: nameSearch ? domain : mergedParams,
+        model,
+        context: parentContext,
+        totalItems: totalRows,
+      });
       changeSelectedRowItems(allRowsResults.map((id: number) => ({ id })));
     };
 
@@ -579,6 +599,7 @@ function SearchTreeInfiniteComp(props: SearchTreeInfiniteProps, ref: any) {
     setSelectedRowItems,
     t,
     totalRows,
+    searchAllIdsRequest,
   ]);
 
   const firstVisibleRowIndex = useCallback(() => {

--- a/src/widgets/views/Tree/treeComponents.tsx
+++ b/src/widgets/views/Tree/treeComponents.tsx
@@ -20,6 +20,7 @@ import {
 import { useActionViewContext } from "@/context/ActionViewContext";
 import { useOne2manyContext } from "@/context/One2manyContext";
 import { DateValue, DateTimeValue } from "@gisce/react-formiga-components";
+import { useNetworkRequest } from "@/hooks/useNetworkRequest";
 
 export const BooleanComponent = ({
   value,
@@ -290,19 +291,22 @@ export const TagsComponent = ({
 }): ReactElement => {
   const [values, setValues] = useState<Array<{ id: number; name: string }>>([]);
   const [loading, setLoading] = useState<boolean>(false);
+  const [readObjects, cancelReadObjectsRequest] = useNetworkRequest(
+    ConnectionProvider.getHandler().readObjects,
+  );
   const { relation, field } = ooui;
 
   const loadValues = useCallback(async () => {
     try {
       setLoading(true);
-      const optionsRead = await ConnectionProvider.getHandler().search({
+      const response = await readObjects({
         model: relation,
-        params: [["id", "in", value.items.map((v: any) => v.id)]],
+        ids: value.items.map((v: any) => v.id),
         fieldsToRetrieve: [field],
         context,
       });
       setValues(
-        optionsRead.map((i: any) => {
+        response.map((i: any) => {
           return { id: i.id, name: i[field] };
         }),
       );
@@ -311,7 +315,7 @@ export const TagsComponent = ({
     } finally {
       setLoading(false);
     }
-  }, [context, field, relation, value?.items]);
+  }, [context, field, relation, value?.items, readObjects]);
 
   useEffect(() => {
     if (value?.items && value?.items.length > 0) {
@@ -319,6 +323,13 @@ export const TagsComponent = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value?.items]);
+
+  useEffect(() => {
+    return () => {
+      cancelReadObjectsRequest();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const tags = useMemo(
     () =>

--- a/src/widgets/views/Tree/treeComponents.tsx
+++ b/src/widgets/views/Tree/treeComponents.tsx
@@ -298,7 +298,7 @@ export const TagsComponent = ({
       const optionsRead = await ConnectionProvider.getHandler().search({
         model: relation,
         params: [["id", "in", value.items.map((v: any) => v.id)]],
-        fields: [field],
+        fieldsToRetrieve: [field],
         context,
       });
       setValues(

--- a/src/widgets/views/Tree/treeComponents.tsx
+++ b/src/widgets/views/Tree/treeComponents.tsx
@@ -202,6 +202,7 @@ export const ColorPickerComponent = ({
 }): ReactElement => {
   return useMemo(
     () => <ColorPicker value={value} disabled showText />,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [ooui, value],
   );
 };


### PR DESCRIPTION
This pull request enhances the `TagsComponent` in `src/widgets/views/Tree/treeComponents.tsx` by introducing a network request hook for improved data fetching and cleanup. The primary changes include replacing the existing data-fetching logic with a reusable hook and ensuring proper cleanup of network requests.

### Enhancements to `TagsComponent`:

* **Integration of `useNetworkRequest` Hook**: Added the `useNetworkRequest` hook for managing network requests, replacing the previous direct calls to `ConnectionProvider.getHandler().search`. This change simplifies the data-fetching logic and improves readability. [[1]](diffhunk://#diff-816e6f9a26910046ab8236a34da9ec95f1192182e533554a4cdf861b4dec39ddR23) [[2]](diffhunk://#diff-816e6f9a26910046ab8236a34da9ec95f1192182e533554a4cdf861b4dec39ddR294-R309)

* **Updated Dependencies for `useCallback`**: Updated the dependency array of the `loadValues` function to include the `readObjects` function from the new hook, ensuring the callback is properly memoized.

* **Cleanup of Network Requests**: Added a `useEffect` to handle cleanup by calling `cancelReadObjectsRequest` when the component unmounts, preventing potential memory leaks from ongoing network requests.

## Related
- Closes https://github.com/gisce/webclient/issues/2369