### PR TITLE
update gisce/react-formiga-table to v1.16.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.33.0-alpha.3",
         "@gisce/react-formiga-components": "1.17.0",
-        "@gisce/react-formiga-table": "1.16.0-alpha.1",
+        "@gisce/react-formiga-table": "1.16.0-alpha.2",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.16.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.1.tgz",
-      "integrity": "sha512-vzzhbDPVA2dpMqNdrm1w882gbHCquZpMptIHIQOHNKRJHLXljs98q87cJWS2y05Xc5R3KyATIZipjPrIoNDg0A==",
+      "version": "1.16.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.2.tgz",
+      "integrity": "sha512-6ep6pPGqywWqc/0Z1IdhetQ7VzkjXQMl73iUABtQVDNrZH9c9YXPVf3ujmAUCqIwrF19wt6lxVaw5K42wF0LOA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.33.0-alpha.3",
     "@gisce/react-formiga-components": "1.17.0",
-    "@gisce/react-formiga-table": "1.16.0-alpha.1",
+    "@gisce/react-formiga-table": "1.16.0-alpha.2",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.16.0-alpha.2](https://github.com/gisce/react-formiga-table/releases/tag/v1.16.0-alpha.2).