### PR TITLE
update gisce/ooui to v2.33.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.33.0-alpha.4",
+        "@gisce/ooui": "2.33.0-alpha.5",
         "@gisce/react-formiga-components": "1.17.0",
         "@gisce/react-formiga-table": "1.16.0-alpha.2",
         "@monaco-editor/react": "^4.4.5",
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.33.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.4.tgz",
-      "integrity": "sha512-hDY0Dj6lZo8+Mc8fwHrwVuKzKpcfNJSiHCwisM2Of+OD3GWxpbtFEhJBVHltIjqFAL94A2MB+nTD+OJ1j4vE4w==",
+      "version": "2.33.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0-alpha.5.tgz",
+      "integrity": "sha512-FWjnBwIRRa1adT5V8sHrXMC5NEaxywGBC/GaBH2MVaRcB2FaAmjCt6xSQLqNVxd6QLpVAWWqUgWV/Tfbuqqhcw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.33.0-alpha.4",
+    "@gisce/ooui": "2.33.0-alpha.5",
     "@gisce/react-formiga-components": "1.17.0",
     "@gisce/react-formiga-table": "1.16.0-alpha.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.33.0-alpha.5](https://github.com/gisce/ooui/releases/tag/v2.33.0-alpha.5).