### PR TITLE
Tree: use new isSortable attribute (and keep old working)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.33.0",
+        "@gisce/ooui": "2.34.0",
         "@gisce/react-formiga-components": "1.17.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0.tgz",
-      "integrity": "sha512-o9edBfKa3bZCjR2qLvyEk+p/kq3RDeZTkix/drFegBRnkgqgRFUEp7PkZS9oTeSrYOk7WrRa/IiUA1ZWLI4MSw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.34.0.tgz",
+      "integrity": "sha512-2Q25HQKooUlYrDYrI0Ntc20iNuX4Go3LUzZKAaIhHHPbyUzIXEYeW/0OEwARNrcBiprNwFsnE2P2wAlOIMrSow==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.33.0",
+    "@gisce/ooui": "2.34.0",
     "@gisce/react-formiga-components": "1.17.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",

--- a/src/helpers/treeHelper.tsx
+++ b/src/helpers/treeHelper.tsx
@@ -79,9 +79,10 @@ const getTableColumns = (
         return 0;
       },
       isSortable:
-        type !== "one2many" &&
-        !column.isFunction &&
-        (type !== "many2one" || many2oneSortEnabled),
+        (type !== "one2many" &&
+          !column.isFunction &&
+          (type !== "many2one" || many2oneSortEnabled)) ||
+        column.isSortable,
     };
   });
   return tableColumns;


### PR DESCRIPTION
This pull request refines the logic for determining column sortability in the `getTableColumns` function within `src/helpers/treeHelper.tsx`. The change ensures that the `isSortable` property accounts for both the type of the column and an explicit `isSortable` flag.

### Key change:

* [`src/helpers/treeHelper.tsx`](diffhunk://#diff-5260245ebbae0c25da2211d9d2e9ab448330da137c5fa8d01f3ac51de3f29b17L82-R85): Updated the `isSortable` logic to include an additional condition where the column's `isSortable` property can explicitly enable sorting, even if other conditions would normally disable it.

### Related

- Requires https://github.com/gisce/ooui/pull/197
- Closes https://github.com/gisce/webclient/issues/2417