### PR TITLE
update gisce/ooui to v2.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/colors": "^7.2.0",
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.33.0",
+        "@gisce/ooui": "2.34.0",
         "@gisce/react-formiga-components": "1.17.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.33.0.tgz",
-      "integrity": "sha512-o9edBfKa3bZCjR2qLvyEk+p/kq3RDeZTkix/drFegBRnkgqgRFUEp7PkZS9oTeSrYOk7WrRa/IiUA1ZWLI4MSw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.34.0.tgz",
+      "integrity": "sha512-2Q25HQKooUlYrDYrI0Ntc20iNuX4Go3LUzZKAaIhHHPbyUzIXEYeW/0OEwARNrcBiprNwFsnE2P2wAlOIMrSow==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ant-design/colors": "^7.2.0",
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.33.0",
+    "@gisce/ooui": "2.34.0",
     "@gisce/react-formiga-components": "1.17.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.34.0](https://github.com/gisce/ooui/releases/tag/v2.34.0).