### PR TITLE
update gisce/react-formiga-components to v1.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.34.0",
-        "@gisce/react-formiga-components": "1.17.0",
+        "@gisce/react-formiga-components": "1.17.1",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -2159,9 +2159,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0.tgz",
-      "integrity": "sha512-b03HMngj6x5xu5fINzzrvrMTlkb0DKfxR7ARWUJ5Qpn4HTMu1YHqY2OyrJFf0fLdhaA5+QrnbY2GydytQouR1g==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.1.tgz",
+      "integrity": "sha512-ztrn+CjuvngzUGzmpjiGM7AkNb9D66Ta3ucCM9NkMMe+sCyp0NRaSN87WD2W439B3sLfubYDx9dFy5Jilb2twQ==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.34.0",
-    "@gisce/react-formiga-components": "1.17.0",
+    "@gisce/react-formiga-components": "1.17.1",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.17.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.17.1).