### PR TITLE
update gisce/react-formiga-components to v1.17.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ant-design/plots": "^1.0.9",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.33.0-alpha.5",
-        "@gisce/react-formiga-components": "1.17.0",
+        "@gisce/react-formiga-components": "1.17.0-alpha.3",
         "@gisce/react-formiga-table": "1.16.0-alpha.2",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -2159,9 +2159,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0.tgz",
-      "integrity": "sha512-b03HMngj6x5xu5fINzzrvrMTlkb0DKfxR7ARWUJ5Qpn4HTMu1YHqY2OyrJFf0fLdhaA5+QrnbY2GydytQouR1g==",
+      "version": "1.17.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0-alpha.3.tgz",
+      "integrity": "sha512-I14PE2+8q6PHerZVeCTsrP6PgV6nYxTHfnSyh/EHGeJTa/fgKNJYHNlk/Rc19skhzWx2c1Q06NrqtsiDMHxY4w==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ant-design/plots": "^1.0.9",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.33.0-alpha.5",
-    "@gisce/react-formiga-components": "1.17.0",
+    "@gisce/react-formiga-components": "1.17.0-alpha.3",
     "@gisce/react-formiga-table": "1.16.0-alpha.2",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.17.0-alpha.3](https://github.com/gisce/react-formiga-components/releases/tag/v1.17.0-alpha.3).