### PR TITLE
fix: pass res_id to form in form modal if there's no id

### DIFF
--- a/src/widgets/modals/FormModal.tsx
+++ b/src/widgets/modals/FormModal.tsx
@@ -112,7 +112,7 @@ export const FormModal = (props: FormModalProps) => {
       >
         <Form
           key={`${model}-${id}-${action_id}-${res_id}-${action_type}-${view_id}-${title}`}
-          id={id}
+          id={id || res_id}
           showFooter={true}
           insideButtonModal={buttonModal}
           onCancel={onCancel}


### PR DESCRIPTION
https://github.com/gisce/webclient/issues/2144