### PR TITLE
update gisce/react-formiga-components to v1.18.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.33.0",
-        "@gisce/react-formiga-components": "1.17.0",
+        "@gisce/react-formiga-components": "1.18.0-rc.1",
         "@gisce/react-formiga-table": "1.16.0-rc.1",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.17.0.tgz",
-      "integrity": "sha512-b03HMngj6x5xu5fINzzrvrMTlkb0DKfxR7ARWUJ5Qpn4HTMu1YHqY2OyrJFf0fLdhaA5+QrnbY2GydytQouR1g==",
+      "version": "1.18.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.18.0-rc.1.tgz",
+      "integrity": "sha512-GPCcsQCK6gbqcbiqqJ676dFkmcyRHFW2tzts6eA1JC9D0QeskwfTKWoie9CZgsJM4bgKDdx0kJ2irWNujHheyQ==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.33.0",
-    "@gisce/react-formiga-components": "1.17.0",
+    "@gisce/react-formiga-components": "1.18.0-rc.1",
     "@gisce/react-formiga-table": "1.16.0-rc.1",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.18.0-rc.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.18.0-rc.1).