### PR TITLE
update gisce/ooui to v2.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.34.0",
+        "@gisce/ooui": "2.35.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.15.0",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.34.0.tgz",
-      "integrity": "sha512-2Q25HQKooUlYrDYrI0Ntc20iNuX4Go3LUzZKAaIhHHPbyUzIXEYeW/0OEwARNrcBiprNwFsnE2P2wAlOIMrSow==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.35.0.tgz",
+      "integrity": "sha512-Xdh3Alcz/HHOS0J5qgQWu3B61Y4eHAszTtdclYzXZBaJmTzzLegwrd0oAVUjQvVYvQiUn5TOeSQMfuhYSZnNtA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.34.0",
+    "@gisce/ooui": "2.35.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.15.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.35.0](https://github.com/gisce/ooui/releases/tag/v2.35.0).