### PR TITLE
update gisce/react-formiga-table to v1.16.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.33.0-alpha.5",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
-        "@gisce/react-formiga-table": "1.16.0-alpha.3",
+        "@gisce/react-formiga-table": "1.16.0-alpha.4",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.16.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.3.tgz",
-      "integrity": "sha512-jHeCdTbugvZ9nWx20e1fJNYfp+lN0m2ohi5d4nB8+bHgRFT6ilfbehEf5frIW8pgyML+U0L1Ryosp2m6yj8MUA==",
+      "version": "1.16.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.4.tgz",
+      "integrity": "sha512-Q9mcNCCH17LA51c6vwYhVG8Z1f094dazUXbVVxPGIc2fk9RGkavJwEFSQlH7SPE0cXxMQLfw5989Ottok123lg==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.33.0-alpha.5",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
-    "@gisce/react-formiga-table": "1.16.0-alpha.3",
+    "@gisce/react-formiga-table": "1.16.0-alpha.4",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.16.0-alpha.4](https://github.com/gisce/react-formiga-table/releases/tag/v1.16.0-alpha.4).