### PR TITLE
update gisce/react-formiga-table to v1.16.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.36.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
-        "@gisce/react-formiga-table": "1.16.0-alpha.5",
+        "@gisce/react-formiga-table": "1.16.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.16.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.5.tgz",
-      "integrity": "sha512-dfcEUje/cSO9oyKHoXptcEzTknZzsF9Urhhg+FaokYCgeBIY8ptN5dDC1cYiBiduBTB3AWQqIehKAkIFvtT+Bg==",
+      "version": "1.16.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0-alpha.6.tgz",
+      "integrity": "sha512-K86DurYigUXnjq8/+8ZQKYHBO+M19rCtCzN7EoYOdCUoIZtca9CB6+a2YaSRbwUVgnOr20s78a5j1aRfw2nEZQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.36.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
-    "@gisce/react-formiga-table": "1.16.0-alpha.5",
+    "@gisce/react-formiga-table": "1.16.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.16.0-alpha.6](https://github.com/gisce/react-formiga-table/releases/tag/v1.16.0-alpha.6).