### PR TITLE
update gisce/react-formiga-table to v1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.35.0",
         "@gisce/react-formiga-components": "1.18.0",
-        "@gisce/react-formiga-table": "1.15.1",
+        "@gisce/react-formiga-table": "1.16.0",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.15.1.tgz",
-      "integrity": "sha512-623HLRDIsvFf6eCvWOABtQJCMi2VeE4YnzTExhOpjLQtepZgiDrM1FsKd/6ukrUZv2FYZGL8w/byQbOnFnnsOw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.0.tgz",
+      "integrity": "sha512-XebiVdMFPNG0RMHU0ouvU7g7qSIe5QD6eIX6QdIKVEsLdH0G+j9pa1fU3H0Tv3Y2yGh3OCiq6XHsqfJxrk06fw==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.35.0",
     "@gisce/react-formiga-components": "1.18.0",
-    "@gisce/react-formiga-table": "1.15.1",
+    "@gisce/react-formiga-table": "1.16.0",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.16.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.16.0).