### PR TITLE
update gisce/ooui to v2.37.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.36.0-alpha.1",
+        "@gisce/ooui": "2.37.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.16.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.36.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.36.0-alpha.1.tgz",
-      "integrity": "sha512-i4Yh/qnbjP08cRUscP+i2BQDcBw9eIS1T2JwilydiZVcEYseBg3mNocboo3gKYI6z1mbBIxFpJnilg7nEuqvSg==",
+      "version": "2.37.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.37.0-alpha.1.tgz",
+      "integrity": "sha512-vlDN1MKiqu2gIcnN2fZ8RZICg+Jl4/etmS6cuxLSREvPnov9RviFsQf1ZaJOHIErnvoeLc1CewJkD9HeMx/NSA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.36.0-alpha.1",
+    "@gisce/ooui": "2.37.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.16.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.37.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.37.0-alpha.1).