### PR TITLE
update gisce/react-formiga-table to v1.17.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.37.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
-        "@gisce/react-formiga-table": "1.17.0-alpha.3",
+        "@gisce/react-formiga-table": "1.17.0-alpha.4",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.17.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.17.0-alpha.3.tgz",
-      "integrity": "sha512-grX+s8jwgqSLw5sKsqCeE4EZZum58dElBU9yzEIUs6DsXITSXQ0xQwunhK8HplFEwQMPZO5b81lD/qFWbDnbLA==",
+      "version": "1.17.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.17.0-alpha.4.tgz",
+      "integrity": "sha512-kPOrY3YTDmA2Eay3oBxR7CbX4H6ywcirKkLMxkp5L8jH7zk4BIr99v4NdC/Kdw06VrFMnjKIFffJWqXwuaa13Q==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.37.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
-    "@gisce/react-formiga-table": "1.17.0-alpha.3",
+    "@gisce/react-formiga-table": "1.17.0-alpha.4",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.17.0-alpha.4](https://github.com/gisce/react-formiga-table/releases/tag/v1.17.0-alpha.4).