### PR TITLE
update gisce/ooui to v2.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.36.0",
+        "@gisce/ooui": "2.37.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.16.1",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.36.0.tgz",
-      "integrity": "sha512-fkrPA/bPf84zwF7dKmtWVMchsrLtxjjgmDA9XH6Zzm16bPud0PMiuyLyYRzCVfez/ULFJU9tqeRh6NYTFmc5Lw==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.37.0.tgz",
+      "integrity": "sha512-5J2fj4aIg+UDJi/snerNs5qvcUKcTKujGckZzwUu3onHwi/5uZc+bD35XEZsRggU0OFVgQ4SDIE8//64Eq377w==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.36.0",
+    "@gisce/ooui": "2.37.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.16.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.37.0](https://github.com/gisce/ooui/releases/tag/v2.37.0).