### PR TITLE
update gisce/ooui to v2.38.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.37.0-alpha.2",
+        "@gisce/ooui": "2.38.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.5",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.37.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.37.0-alpha.2.tgz",
-      "integrity": "sha512-VHEBGYZbj9PS8nNXulnd7XTbPy/JcvbSiJ2ny36amVFw8nn1O8DsvkbWYnpP58+kt7KHB527YXJXZqyYA/WfCQ==",
+      "version": "2.38.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.38.0-alpha.1.tgz",
+      "integrity": "sha512-gWDm8QphbKb98PbwcfPlwB30ljzv2Jpp97dPk0PQqb1TzDGkAlVjzY5G5wbYVXNjPXoZjA92wU0qDVYCws7OSA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.37.0-alpha.2",
+    "@gisce/ooui": "2.38.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.5",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.38.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.38.0-alpha.1).