### PR TITLE
feat: add Card widget support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { ProgressBar } from "@/widgets/base/ProgressBar";
 import { FloatTime } from "@/widgets/base/FloatTime";
 import { Integer } from "@/widgets/base/Integer";
 import Group from "@/widgets/containers/Group";
+import Card from "@/widgets/containers/Card";
 import Notebook from "@/widgets/containers/Notebook";
 import Form from "@/widgets/views/Form";
 import Label from "@/widgets/base/Label";
@@ -118,6 +119,7 @@ export {
   Many2one,
   Tree,
   Group,
+  Card,
   SearchFilter,
   Form,
   Notebook,

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -46,6 +46,7 @@ import { Indicator } from "./custom/Indicator";
 import { Tags } from "./custom/Tags";
 import { ActionButtons } from "./custom/ActionButtons";
 import { QRCode } from "./custom/QRCode";
+import Card from "./containers/Card";
 import { createElement } from "react";
 
 const getWidgetType = (type: string) => {
@@ -145,6 +146,8 @@ const getWidgetType = (type: string) => {
       return ActionButtons;
     case "qrcode":
       return QRCode;
+    case "card":
+      return Card;
     default:
       return undefined;
   }

--- a/src/widgets/containers/Card.tsx
+++ b/src/widgets/containers/Card.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Card as CardOoui } from "@gisce/ooui";
+import { Spinner } from "@/widgets/custom/Spinner";
+import { Card as AntCard } from "antd";
+import { useLocale, iconMapper } from "@gisce/react-formiga-components";
+
+type Props = {
+  ooui: CardOoui;
+  responsiveBehaviour: boolean;
+};
+
+function Card(props: Props): React.ReactElement {
+  const { ooui, responsiveBehaviour } = props;
+  const icon: React.ElementType | undefined = iconMapper(ooui.icon || "");
+  const { t } = useLocale();
+
+  const title = ooui.title ? (
+    <span>
+      {icon && (
+        <span style={{ marginRight: "8px" }}>{React.createElement(icon)}</span>
+      )}
+      {ooui.title}
+    </span>
+  ) : undefined;
+
+  return (
+    <AntCard
+      title={title}
+      style={{
+        height: ooui.height ? ooui.height + "px" : "100%",
+      }}
+    >
+      <Spinner
+        tip={t("loading")}
+        ooui={ooui}
+        responsiveBehaviour={responsiveBehaviour}
+      />
+    </AntCard>
+  );
+}
+
+export default Card;


### PR DESCRIPTION
This pull request introduces a new `Card` container widget to the codebase and integrates it into the widget factory and exports. The `Card` widget leverages Ant Design's `Card` component and supports features like icon mapping and loading spinners. 

<img width="1211" height="161" alt="image" src="https://github.com/user-attachments/assets/bcff6f84-1cfb-44cf-87ba-c2bf2fa35a3d" />


The main changes are:

**New Widget Implementation:**

* Added a new `Card` container component in `src/widgets/containers/Card.tsx`, which uses Ant Design's `Card`, supports icons via `iconMapper`, and displays a loading spinner using the `Spinner` component.

**Widget Factory Integration:**

* Registered the new `Card` widget in the widget factory by importing it and returning it when the `"card"` type is requested in `src/widgets/WidgetFactory.tsx`. [[1]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R49) [[2]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R149-R150)

**Exports and Imports:**

* Added the `Card` widget to the main exports in `src/index.ts` so it can be used throughout the project. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R14) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R122)

## Related
- Requires: https://github.com/gisce/ooui/pull/213
