### PR TITLE
update gisce/ooui to v2.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.38.0",
+        "@gisce/ooui": "2.39.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.16.1",
         "@monaco-editor/react": "^4.4.5",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.38.0.tgz",
-      "integrity": "sha512-VavjJezAsV+r0syAmpS9fTOg7oaAiR5DZMi0Zm+d83Q79unWydo+HX711wbUjxWR3aAAyTL/qyuChkN7AybmiA==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.39.0.tgz",
+      "integrity": "sha512-5AGUyN1O2jdfFAD0ACrgUFwouKwdC/aPYVx6knwyb9Yrnq6BEzbqal/BBnmJWuNTbas9XBLr4p+JBI8OQ8j5NQ==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.38.0",
+    "@gisce/ooui": "2.39.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.16.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.39.0](https://github.com/gisce/ooui/releases/tag/v2.39.0).