### PR TITLE
feat: add total value to stacked bar chart tooltip

### DIFF
--- a/src/widgets/views/Graph/GraphChartComp.tsx
+++ b/src/widgets/views/Graph/GraphChartComp.tsx
@@ -210,6 +210,36 @@ function getGraphProps(props: GetGraphPropsType) {
     if (isStack) {
       graphProps.isStack = true;
       graphProps.groupField = "stacked";
+      graphProps.tooltip = {
+        fields: ["type", "value", "x"],
+        formatter: (datum: any) => {
+          const formattedValue = datum.value.toLocaleString("es-ES", {
+            useGrouping: true,
+          });
+          return {
+            name: datum.type,
+            value: formattedValue,
+          };
+        },
+        customItems: (originalItems: any[]) => {
+          if (originalItems.length === 0) return originalItems;
+          const xValue = originalItems[0].data.x;
+          const total = data
+            .filter((item) => item.x === xValue)
+            .reduce((acc, item) => acc + item.value, 0);
+          const totalFormatted = total.toLocaleString("es-ES", {
+            useGrouping: true,
+          });
+          return [
+            ...originalItems,
+            {
+              name: "Total",
+              value: totalFormatted,
+              color: "transparent",
+            },
+          ];
+        },
+      };
     }
   }
 


### PR DESCRIPTION
Add total sum of all stacks to the tooltip when hovering over stacked bar charts. The total is displayed as an additional item at the bottom of the tooltip.

Uses Ant Design Charts customItems API to append the total in a clean, integrated way without custom HTML rendering.

## Related
- Closes https://github.com/gisce/webclient/issues/2380