### PR TITLE
update gisce/ooui to v2.40.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.38.0-alpha.3",
+        "@gisce/ooui": "2.40.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.5",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.38.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.38.0-alpha.3.tgz",
-      "integrity": "sha512-soagkGlUIxflWqsN+eulIDpGelUU60THebBvFbVYfwRF3wGgjcDT9oGldK+bpg6n5BfBMmhUdd4oChVdXz6iWw==",
+      "version": "2.40.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.1.tgz",
+      "integrity": "sha512-XkR/0OgAYbp/PlBZOtoDdLYDJnApKFt++VTuVTht6It70TEv/ai1HZC4oBElrtk+GSakupgB80L7ZTc+rjg+Jg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.38.0-alpha.3",
+    "@gisce/ooui": "2.40.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.5",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.40.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.40.0-alpha.1).