### PR TITLE
feat(Image): support width and height for icons and images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.39.0",
+        "@gisce/ooui": "2.40.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.16.1",
         "@monaco-editor/react": "^4.4.5",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.39.0.tgz",
-      "integrity": "sha512-5AGUyN1O2jdfFAD0ACrgUFwouKwdC/aPYVx6knwyb9Yrnq6BEzbqal/BBnmJWuNTbas9XBLr4p+JBI8OQ8j5NQ==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0.tgz",
+      "integrity": "sha512-BdUy0Rk//w73Cn3zSGe8zkeBNvFueUhIEqKlOkVgmut5GB1BfeZMHiVNMJlG/l2+/hs5CTgdLhxEIAuB7witzg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.39.0",
+    "@gisce/ooui": "2.40.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.16.1",
     "@monaco-editor/react": "^4.4.5",

--- a/src/widgets/base/Image.tsx
+++ b/src/widgets/base/Image.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ant-design/icons";
 
 import { toBase64, getMimeType } from "@/helpers/filesHelper";
-import { iconMapper, useLocale } from "@gisce/react-formiga-components";
+import { Icon, iconMapper, useLocale } from "@gisce/react-formiga-components";
 
 type ImageProps = {
   ooui: ImageOoui;
@@ -19,31 +19,43 @@ type ImageProps = {
 type ImageRenderProps = {
   value?: string;
   style?: any;
+  width?: number;
+  height?: number;
 };
 
 export const ImageRender = (props: ImageRenderProps) => {
-  const { value, style = {} } = props;
+  const { value, style = {}, width, height } = props;
   if (value) {
-    const Icon: React.ElementType = iconMapper(value) as any;
-    if (Icon) {
-      return <Icon />;
+    const size = height || width;
+    const iconStyle: any = size ? { fontSize: size } : {};
+    const MappedIcon = iconMapper(
+      value,
+      size ? { style: iconStyle } : undefined,
+    );
+    if (MappedIcon) {
+      return <MappedIcon />;
     } else {
-      return (
-        <img
-          src={`data:image/*;base64,${value}`}
-          style={{ ...{ maxWidth: "100px" }, ...style }}
-        />
-      );
+      const imgStyle: any = { ...style };
+      if (width) {
+        imgStyle.width = `${width}px`;
+      }
+      if (height) {
+        imgStyle.height = `${height}px`;
+      }
+      if (!width && !height) {
+        imgStyle.maxWidth = "100px";
+      }
+      return <img src={`data:image/*;base64,${value}`} style={imgStyle} />;
     }
   }
 };
 
 export const Image = (props: ImageProps) => {
   const { ooui } = props;
-  const { required, id } = ooui;
+  const { required, id, width, height } = ooui;
 
   if (iconMapper(id)) {
-    return <ImageRender value={id} />;
+    return <ImageRender value={id} width={width} height={height} />;
   }
 
   return (
@@ -61,7 +73,7 @@ interface ImageInputProps {
 
 export const ImageInput = (props: ImageInputProps) => {
   const { ooui, value, onChange } = props;
-  const { readOnly } = ooui as ImageOoui;
+  const { readOnly, width, height } = ooui as ImageOoui;
   const inputFile = useRef(null);
   const { t } = useLocale();
 
@@ -96,9 +108,9 @@ export const ImageInput = (props: ImageInputProps) => {
       <Row gutter={8} wrap={false} justify="center">
         {useMemo(
           () => (
-            <ImageRender value={value} />
+            <ImageRender value={value} width={width} height={height} />
           ),
-          [value],
+          [value, width, height],
         )}
         <input
           type="file"

--- a/src/widgets/base/Image.tsx
+++ b/src/widgets/base/Image.tsx
@@ -36,13 +36,16 @@ export const ImageRender = (props: ImageRenderProps) => {
       return <MappedIcon />;
     } else {
       const imgStyle: any = { ...style };
-      if (width) {
+      if (width && height) {
         imgStyle.width = `${width}px`;
-      }
-      if (height) {
         imgStyle.height = `${height}px`;
-      }
-      if (!width && !height) {
+      } else if (width) {
+        imgStyle.width = `${width}px`;
+        imgStyle.height = "auto";
+      } else if (height) {
+        imgStyle.height = `${height}px`;
+        imgStyle.width = "auto";
+      } else {
         imgStyle.maxWidth = "100px";
       }
       return <img src={`data:image/*;base64,${value}`} style={imgStyle} />;


### PR DESCRIPTION
- Apply fontSize to icons based on width/height from OOUI
- Apply width/height styles to base64 images
- Update ImageRender to accept width and height props
- Pass width and height from OOUI to ImageRender component


## Related
- Needs https://github.com/gisce/ooui/pull/219
- Closes https://github.com/gisce/webclient/issues/2673