### PR TITLE
Icon component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import ActionBar from "@/actionbar/FormActionBar";
 import { Url } from "@/widgets/base/Url";
 import { Email } from "@/widgets/base/Email";
 import { Image } from "@/widgets/base/Image";
+import { Icon } from "@/widgets/base/Icon";
 import showConfirmDialog from "@/ui/ConfirmDialog";
 import Dashboard from "@/widgets/views/Dashboard/Dashboard";
 import { Tags } from "@/widgets/custom/Tags";
@@ -168,6 +169,7 @@ export {
   Url,
   Email,
   Image,
+  Icon,
   ContentRootProvider,
   showConfirmDialog,
   NameSearchRequest,

--- a/src/widgets/WidgetFactory.tsx
+++ b/src/widgets/WidgetFactory.tsx
@@ -40,6 +40,7 @@ import {
   ColorPicker,
 } from "@/index";
 import { Image } from "./base/Image";
+import { Icon } from "./base/Icon";
 import { FiberGrid } from "./custom/FiberGrid";
 import { Timeline } from "./custom/Timeline";
 import { Indicator } from "./custom/Indicator";
@@ -99,6 +100,8 @@ const getWidgetType = (type: string) => {
       return Binary;
     case "image":
       return Image;
+    case "icon":
+      return Icon;
     case "url":
       return Url;
     case "email":

--- a/src/widgets/base/Icon.tsx
+++ b/src/widgets/base/Icon.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import Field from "@/common/Field";
+import { Icon as IconOoui } from "@gisce/ooui";
+import { iconMapper } from "@gisce/react-formiga-components";
+
+type IconProps = {
+  ooui: IconOoui;
+};
+
+type IconRenderProps = {
+  name: string;
+  size?: number;
+  color?: string;
+};
+
+export const IconRender = (props: IconRenderProps) => {
+  const { name, size, color } = props;
+
+  const iconStyle: any = {};
+  if (size) {
+    iconStyle.fontSize = size;
+  }
+  if (color) {
+    iconStyle.color = color;
+  }
+
+  const MappedIcon = iconMapper(
+    name,
+    Object.keys(iconStyle).length > 0 ? { style: iconStyle } : undefined,
+  );
+
+  if (MappedIcon) {
+    return <MappedIcon />;
+  }
+
+  return null;
+};
+
+export const Icon = (props: IconProps) => {
+  const { ooui } = props;
+  const { required, name, size, color } = ooui as any;
+
+  // If name is directly an icon (static usage like <icon name="home" />)
+  if (iconMapper(name)) {
+    return <IconRender name={name} size={size} color={color} />;
+  }
+
+  // Otherwise, it's a field and needs to receive value from Field component
+  return (
+    <Field required={required} {...props}>
+      <IconInput ooui={ooui} />
+    </Field>
+  );
+};
+
+interface IconInputProps {
+  ooui: IconOoui;
+  value?: string;
+}
+
+export const IconInput = (props: IconInputProps) => {
+  const { ooui, value } = props;
+  const { size, color } = ooui as any;
+
+  if (value && iconMapper(value)) {
+    return <IconRender name={value} size={size} color={color} />;
+  }
+
+  // If no icon is found, log to console but don't render anything
+  if (value) {
+    console.warn(`Icon not found: ${value}`);
+  }
+
+  return null;
+};

--- a/src/widgets/base/Image.tsx
+++ b/src/widgets/base/Image.tsx
@@ -10,7 +10,8 @@ import {
 } from "@ant-design/icons";
 
 import { toBase64, getMimeType } from "@/helpers/filesHelper";
-import { Icon, iconMapper, useLocale } from "@gisce/react-formiga-components";
+import { iconMapper, useLocale } from "@gisce/react-formiga-components";
+import { IconRender } from "./Icon";
 
 type ImageProps = {
   ooui: ImageOoui;
@@ -27,13 +28,8 @@ export const ImageRender = (props: ImageRenderProps) => {
   const { value, style = {}, width, height } = props;
   if (value) {
     const size = height || width;
-    const iconStyle: any = size ? { fontSize: size } : {};
-    const MappedIcon = iconMapper(
-      value,
-      size ? { style: iconStyle } : undefined,
-    );
-    if (MappedIcon) {
-      return <MappedIcon />;
+    if (iconMapper(value)) {
+      return <IconRender name={value} size={size} />;
     } else {
       const imgStyle: any = { ...style };
       if (width && height) {
@@ -55,7 +51,7 @@ export const ImageRender = (props: ImageRenderProps) => {
 
 export const Image = (props: ImageProps) => {
   const { ooui } = props;
-  const { required, id, width, height } = ooui;
+  const { required, id, width, height } = ooui as any;
 
   if (iconMapper(id)) {
     return <ImageRender value={id} width={width} height={height} />;


### PR DESCRIPTION
This pull request introduces a new `Icon` widget to the codebase and integrates it into the widget factory system, allowing icons to be rendered as standalone widgets or as part of other components. It also refactors the `Image` widget to leverage the new `IconRender` component for icon rendering, improving consistency and code reuse.

**New Icon widget and integration:**

* Added a new `Icon` widget in `src/widgets/base/Icon.tsx`, including `Icon`, `IconRender`, and `IconInput` components to handle both static and dynamic icon rendering using the `iconMapper` utility.
* Registered the new `Icon` widget in the main exports (`src/index.ts`) and in the `WidgetFactory` so that it can be instantiated dynamically based on the widget type. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R38) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R172) [[3]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R43) [[4]](diffhunk://#diff-7c21a9582c89fd62c428d7e6a7c2e7d01fc8a625824177c2874cddde77bfe5c1R103-R104)

**Refactoring and code reuse:**

* Updated the `Image` widget (`src/widgets/base/Image.tsx`) to use the new `IconRender` component for icon rendering, ensuring consistent icon rendering logic across widgets and removing redundant code. [[1]](diffhunk://#diff-c445be294969e552ad77fa891cfc64e3ee4d10aad10ee909ca7f8a26a0ce5241L13-R14) [[2]](diffhunk://#diff-c445be294969e552ad77fa891cfc64e3ee4d10aad10ee909ca7f8a26a0ce5241L30-R32) [[3]](diffhunk://#diff-c445be294969e552ad77fa891cfc64e3ee4d10aad10ee909ca7f8a26a0ce5241L58-R54)


## Related
- Needs https://github.com/gisce/ooui/pull/220
- Closes https://github.com/gisce/webclient/issues/1876