### PR TITLE
update gisce/ooui to v2.40.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.40.0-alpha.2",
+        "@gisce/ooui": "2.40.0-alpha.3",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.40.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.2.tgz",
-      "integrity": "sha512-y3Zdh4Gxg0wRjkdtBb1G2OCe9R4o/+NqFDxOiGm3jE6mh1NRYGdaCj/OeDUPt3xTQlb9CVcMUBe2+jHzPgVoGQ==",
+      "version": "2.40.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.3.tgz",
+      "integrity": "sha512-e7+4cjJ8k+ZeRRwbt08bWq8g0FLpUdDH1evbXnkvii4tal15AOfIG7EgdpSnoa6zvt7aLim4YN93xojjdWhF+w==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.40.0-alpha.2",
+    "@gisce/ooui": "2.40.0-alpha.3",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.40.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.40.0-alpha.3).