### PR TITLE
feat(GraphIndicator): add progressbar property to display indicators …

### DIFF
--- a/src/widgets/views/Graph/Graph.tsx
+++ b/src/widgets/views/Graph/Graph.tsx
@@ -110,6 +110,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
       return (
         <GraphIndicator
           showPercent={indicator.showPercent}
+          showTotal={indicator.showTotal}
           progressbar={indicator.progressbar}
           totalDomain={indicator.totalDomain!}
           colorCondition={indicator.color}

--- a/src/widgets/views/Graph/Graph.tsx
+++ b/src/widgets/views/Graph/Graph.tsx
@@ -110,6 +110,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
       return (
         <GraphIndicator
           showPercent={indicator.showPercent}
+          progressbar={indicator.progressbar}
           totalDomain={indicator.totalDomain!}
           colorCondition={indicator.color}
           model={model}

--- a/src/widgets/views/Graph/GraphIndicator.tsx
+++ b/src/widgets/views/Graph/GraphIndicator.tsx
@@ -22,6 +22,7 @@ export type GraphInidicatorProps = {
   operator?: Operator;
   manualIds?: number[];
   fixedHeight?: number;
+  showTotal?: boolean;
 };
 
 export const GraphIndicator = (props: GraphInidicatorProps) => {
@@ -39,6 +40,7 @@ export const GraphIndicator = (props: GraphInidicatorProps) => {
     operator,
     manualIds,
     fixedHeight,
+    showTotal,
   } = props;
   const [loading, setLoading] = useState(false);
   const [value, setValue] = useState<number>();
@@ -212,7 +214,7 @@ export const GraphIndicator = (props: GraphInidicatorProps) => {
   return (
     <GraphIndicatorComp
       value={value!}
-      totalValue={totalValue!}
+      totalValue={showTotal !== false ? totalValue! : undefined}
       percent={percent!}
       color={color}
       icon={icon}

--- a/src/widgets/views/Graph/GraphIndicator.tsx
+++ b/src/widgets/views/Graph/GraphIndicator.tsx
@@ -15,6 +15,7 @@ export type GraphInidicatorProps = {
   colorCondition?: string | null;
   totalDomain?: string;
   showPercent?: boolean;
+  progressbar?: boolean;
   icon?: string;
   suffix?: string;
   field?: string;
@@ -31,6 +32,7 @@ export const GraphIndicator = (props: GraphInidicatorProps) => {
     colorCondition,
     totalDomain,
     showPercent = false,
+    progressbar = false,
     icon: iconProps,
     suffix,
     field,
@@ -216,6 +218,7 @@ export const GraphIndicator = (props: GraphInidicatorProps) => {
       icon={icon}
       suffix={suffix}
       showPercent={showPercent}
+      progressbar={progressbar}
       fixedHeight={fixedHeight}
     />
   );

--- a/src/widgets/views/Graph/GraphIndicatorComp.tsx
+++ b/src/widgets/views/Graph/GraphIndicatorComp.tsx
@@ -149,7 +149,8 @@ function CommonIndicator({
     useGrouping: true,
   });
 
-  let finalValue = total ? `${localeValue}/${totalValue}` : `${localeValue}`;
+  let finalValue =
+    total !== undefined ? `${localeValue}/${totalValue}` : `${localeValue}`;
 
   if (suffix) {
     finalValue += " " + suffix;
@@ -223,11 +224,12 @@ function PercentageIndicator({
     useGrouping: true,
   });
 
-  let finalValue = total
-    ? `${localeValue}/${total?.toLocaleString("es-ES", {
-        useGrouping: true,
-      })}`
-    : `${localeValue}`;
+  let finalValue =
+    total !== undefined
+      ? `${localeValue}/${total?.toLocaleString("es-ES", {
+          useGrouping: true,
+        })}`
+      : `${localeValue}`;
 
   if (suffix) {
     finalValue += " " + suffix;

--- a/src/widgets/views/Graph/GraphIndicatorComp.tsx
+++ b/src/widgets/views/Graph/GraphIndicatorComp.tsx
@@ -3,7 +3,7 @@ import Measure from "react-measure";
 import Title from "antd/lib/typography/Title";
 import { iconMapper } from "@gisce/react-formiga-components";
 
-import { Col, Row } from "antd";
+import { Col, Row, Progress } from "antd";
 
 const fontGrowFactor = 0.7;
 const minFontSize = 30;
@@ -16,6 +16,7 @@ export type GraphIndicatorCompProps = {
   icon?: string;
   suffix?: string;
   showPercent?: boolean;
+  progressbar?: boolean;
   fixedHeight?: number;
 };
 
@@ -31,6 +32,7 @@ export const GraphIndicatorComp = (props: GraphIndicatorCompProps) => {
     icon,
     suffix,
     showPercent,
+    progressbar,
     fixedHeight,
   } = props;
 
@@ -43,14 +45,20 @@ export const GraphIndicatorComp = (props: GraphIndicatorCompProps) => {
       }}
     >
       {({ measureRef }) => {
-        const content = showPercent ? (
+        const availableHeight = fixedHeight || height || 200;
+        const availableWidth = width || 200;
+        const minDimension = Math.min(availableHeight, availableWidth);
+        const circleSize = minDimension > 0 ? minDimension : 200;
+        const innerSize = circleSize;
+
+        const indicatorContent = showPercent ? (
           <PercentageIndicator
             value={value!}
             total={totalValue!}
             percent={percent!}
-            measureRef={measureRef}
-            height={fixedHeight || height}
-            width={width}
+            measureRef={progressbar ? undefined : measureRef}
+            height={progressbar ? innerSize : availableHeight}
+            width={progressbar ? innerSize : availableWidth}
             color={color}
             icon={icon}
             suffix={suffix}
@@ -59,13 +67,36 @@ export const GraphIndicatorComp = (props: GraphIndicatorCompProps) => {
           <CommonIndicator
             value={value!}
             total={totalValue}
-            measureRef={measureRef}
-            height={fixedHeight || height}
-            width={width}
+            measureRef={progressbar ? undefined : measureRef}
+            height={progressbar ? innerSize : availableHeight}
+            width={progressbar ? innerSize : availableWidth}
             color={color}
             icon={icon}
             suffix={suffix}
           />
+        );
+
+        const content = progressbar ? (
+          <div
+            ref={measureRef}
+            style={{
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Progress
+              type="circle"
+              percent={percent || 0}
+              strokeColor={color}
+              width={circleSize}
+              format={() => indicatorContent}
+            />
+          </div>
+        ) : (
+          indicatorContent
         );
 
         return fixedHeight ? (

--- a/src/widgets/views/Graph/GraphIndicatorComp.tsx
+++ b/src/widgets/views/Graph/GraphIndicatorComp.tsx
@@ -51,14 +51,18 @@ export const GraphIndicatorComp = (props: GraphIndicatorCompProps) => {
         const circleSize = minDimension > 0 ? minDimension : 200;
         const innerSize = circleSize;
 
+        // For non-progressbar indicators, use old simple logic (no fallbacks)
+        const simpleHeight = fixedHeight || height;
+        const simpleWidth = width;
+
         const indicatorContent = showPercent ? (
           <PercentageIndicator
             value={value!}
             total={totalValue!}
             percent={percent!}
             measureRef={progressbar ? undefined : measureRef}
-            height={progressbar ? innerSize : availableHeight}
-            width={progressbar ? innerSize : availableWidth}
+            height={progressbar ? innerSize : simpleHeight}
+            width={progressbar ? innerSize : simpleWidth}
             color={color}
             icon={icon}
             suffix={suffix}
@@ -68,8 +72,8 @@ export const GraphIndicatorComp = (props: GraphIndicatorCompProps) => {
             value={value!}
             total={totalValue}
             measureRef={progressbar ? undefined : measureRef}
-            height={progressbar ? innerSize : availableHeight}
-            width={progressbar ? innerSize : availableWidth}
+            height={progressbar ? innerSize : simpleHeight}
+            width={progressbar ? innerSize : simpleWidth}
             color={color}
             icon={icon}
             suffix={suffix}

--- a/src/widgets/views/Graph/GraphServer.tsx
+++ b/src/widgets/views/Graph/GraphServer.tsx
@@ -66,8 +66,23 @@ const GraphComp = (props: GraphProps, ref: any) => {
   switch (graphData.type) {
     case "indicatorField":
     case "indicator": {
-      const { value, total, percent, icon, color, suffix } =
-        graphData as GraphResponseIndicator;
+      const {
+        value,
+        total,
+        percent,
+        icon,
+        color,
+        suffix,
+        progressbar,
+        showPercent,
+      } = graphData as GraphResponseIndicator;
+
+      const shouldShowPercent =
+        showPercent !== undefined
+          ? showPercent
+          : progressbar
+          ? false
+          : isNumber(percent);
 
       return (
         <GraphIndicatorComp
@@ -77,7 +92,8 @@ const GraphComp = (props: GraphProps, ref: any) => {
           color={color}
           icon={icon}
           suffix={suffix}
-          showPercent={isNumber(percent)}
+          showPercent={shouldShowPercent}
+          progressbar={progressbar}
           fixedHeight={fixedHeight}
         />
       );

--- a/src/widgets/views/Graph/GraphServer.tsx
+++ b/src/widgets/views/Graph/GraphServer.tsx
@@ -75,6 +75,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
         suffix,
         progressbar,
         showPercent,
+        showTotal,
       } = graphData as GraphResponseIndicator;
 
       const shouldShowPercent =
@@ -87,7 +88,7 @@ const GraphComp = (props: GraphProps, ref: any) => {
       return (
         <GraphIndicatorComp
           value={value}
-          totalValue={total}
+          totalValue={showTotal !== false ? total : undefined}
           percent={percent}
           color={color}
           icon={icon}

--- a/src/widgets/views/Graph/useServerGraphData.tsx
+++ b/src/widgets/views/Graph/useServerGraphData.tsx
@@ -30,6 +30,8 @@ export type GraphResponseIndicator = GraphResponse & {
   icon?: string;
   percent?: number;
   suffix?: string;
+  progressbar?: boolean;
+  showPercent?: boolean;
 };
 
 export const useServerGraphData = (opts: GraphDataQueryOpts) => {

--- a/src/widgets/views/Graph/useServerGraphData.tsx
+++ b/src/widgets/views/Graph/useServerGraphData.tsx
@@ -32,6 +32,7 @@ export type GraphResponseIndicator = GraphResponse & {
   suffix?: string;
   progressbar?: boolean;
   showPercent?: boolean;
+  showTotal?: boolean;
 };
 
 export const useServerGraphData = (opts: GraphDataQueryOpts) => {


### PR DESCRIPTION
This pull request adds support for displaying a circular progress bar in the graph indicator components. The main change introduces a new `progressbar` prop, which, when enabled, wraps the indicator content in an Ant Design circular `Progress` component for enhanced visual representation.

**Progress bar feature integration:**

* Added a new `progressbar` prop to `GraphIndicator`, `GraphIndicatorComp`, and their respective prop types, allowing components to optionally render a circular progress bar. [[1]](diffhunk://#diff-52ddd12e8ec27406e50a67a5af57b9f584d11549540b10d89108110285785a1eR18) [[2]](diffhunk://#diff-52ddd12e8ec27406e50a67a5af57b9f584d11549540b10d89108110285785a1eR35) [[3]](diffhunk://#diff-52ddd12e8ec27406e50a67a5af57b9f584d11549540b10d89108110285785a1eR221) [[4]](diffhunk://#diff-9fee5a778572dbd75a5c344f3d447b30d74ee91e686fd52e8c22888514fbaed8R19) [[5]](diffhunk://#diff-9fee5a778572dbd75a5c344f3d447b30d74ee91e686fd52e8c22888514fbaed8R35)
* Updated `GraphComp` to pass the `progressbar` prop down to `GraphIndicator`.

**UI rendering enhancements:**

* Modified `GraphIndicatorComp` to render the indicator content inside an Ant Design `Progress` circle when `progressbar` is true, including dynamic sizing and layout adjustments. [[1]](diffhunk://#diff-9fee5a778572dbd75a5c344f3d447b30d74ee91e686fd52e8c22888514fbaed8L46-R61) [[2]](diffhunk://#diff-9fee5a778572dbd75a5c344f3d447b30d74ee91e686fd52e8c22888514fbaed8L62-R101)
* Imported the `Progress` component from Ant Design to enable the new progress bar feature.

## Related
- Needs https://github.com/gisce/ooui/pull/223
- Closes https://github.com/gisce/webclient/issues/2656