### PR TITLE
update gisce/ooui to v2.40.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.40.0-alpha.3",
+        "@gisce/ooui": "2.40.0-alpha.4",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.40.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.3.tgz",
-      "integrity": "sha512-e7+4cjJ8k+ZeRRwbt08bWq8g0FLpUdDH1evbXnkvii4tal15AOfIG7EgdpSnoa6zvt7aLim4YN93xojjdWhF+w==",
+      "version": "2.40.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.4.tgz",
+      "integrity": "sha512-ZdEfcN4DsqrlZkkWMZz0CgKvMJX9/rraIRkVEwePwMVjk1ArDH0afibEq9h21KTKIDoHK9SjpQIr7AHiwEfBOg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.40.0-alpha.3",
+    "@gisce/ooui": "2.40.0-alpha.4",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.40.0-alpha.4](https://github.com/gisce/ooui/releases/tag/v2.40.0-alpha.4).