### PR TITLE
update gisce/react-formiga-table to v1.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.40.0",
         "@gisce/react-formiga-components": "1.18.0",
-        "@gisce/react-formiga-table": "1.16.1",
+        "@gisce/react-formiga-table": "1.16.2",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2513,9 +2513,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.1.tgz",
-      "integrity": "sha512-MlSXkX3kifnn//5uGOAA5/Vuz8VFvZBvbWIHDXrDS4WvbiEGzPmAJ76D/SkjzkdBVgFsuy3cMbiZ5jQyHn/VFw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.2.tgz",
+      "integrity": "sha512-mPb69ozEQFSZ17xsgNzkJtpRUHq7KGaToHRc++DYUjqXLzMh52/LZWupqAgvE3mEQSsf3e/QoCgvktKqJ3pQbA==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.40.0",
     "@gisce/react-formiga-components": "1.18.0",
-    "@gisce/react-formiga-table": "1.16.1",
+    "@gisce/react-formiga-table": "1.16.2",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.16.2](https://github.com/gisce/react-formiga-table/releases/tag/v1.16.2).