### PR TITLE
update gisce/ooui to v2.40.0-alpha.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.40.0-alpha.6",
+        "@gisce/ooui": "2.40.0-alpha.7",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.40.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.6.tgz",
-      "integrity": "sha512-eURd4xuV5+1VbUINvtRyz0BAl8M/B6j9fIchaDwF1dVRk4PMyNp7gwmJc51MH0O2zz9uuf4ioIAjaYsXf4aVBg==",
+      "version": "2.40.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.7.tgz",
+      "integrity": "sha512-QN1D3BTkAPK0w8p8vVdrjFO41q/HpGq1BFO1YQtmooG8x0+00B9GryrXGCsbHVdnhL4DNw1YtilNjXCaKoVSeA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.40.0-alpha.6",
+    "@gisce/ooui": "2.40.0-alpha.7",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.40.0-alpha.7](https://github.com/gisce/ooui/releases/tag/v2.40.0-alpha.7).