### PR TITLE
update gisce/ooui to v2.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.40.0",
+        "@gisce/ooui": "2.41.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.16.2",
         "@monaco-editor/react": "^4.4.5",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0.tgz",
-      "integrity": "sha512-BdUy0Rk//w73Cn3zSGe8zkeBNvFueUhIEqKlOkVgmut5GB1BfeZMHiVNMJlG/l2+/hs5CTgdLhxEIAuB7witzg==",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.41.0.tgz",
+      "integrity": "sha512-ikvA5Mwabij2X6D8OeHhS9a62zuC+bEKP85cmWtcTmA+7/MaIfBh0NWn+ZTwBRH56TIPdAMawAwAiOYC432Krw==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.40.0",
+    "@gisce/ooui": "2.41.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.16.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.41.0](https://github.com/gisce/ooui/releases/tag/v2.41.0).