### PR TITLE
update gisce/ooui to v2.43.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.40.0-alpha.9",
+        "@gisce/ooui": "2.43.0-alpha.1",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.40.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.40.0-alpha.9.tgz",
-      "integrity": "sha512-OnmPMXO0vsL8dnQZ9F76xQE502+p8zaObqUgw1MwP9UZVEH1cmuwv6mWOiQqwAZQ2+LOzzH6VRxxZiHdMj1Muw==",
+      "version": "2.43.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.43.0-alpha.1.tgz",
+      "integrity": "sha512-qfDJsh7Ta2zn1DnFx65Nfa/nNjnY7FDq33+FFhY2trimDgEoXrzlojbgOx7w07faj9FTw83VrhGIfCrw9rJhQA==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.40.0-alpha.9",
+    "@gisce/ooui": "2.43.0-alpha.1",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.43.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.43.0-alpha.1).