### PR TITLE
update gisce/ooui to v2.43.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.43.0-alpha.2",
+        "@gisce/ooui": "2.43.0-alpha.3",
         "@gisce/react-formiga-components": "1.18.0-alpha.2",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.43.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.43.0-alpha.2.tgz",
-      "integrity": "sha512-oW00RJLgM7sdddLd1+PATsu9DV/IPV/UFWn05rKIVhv1wE5GAQm4NTQ7SS19iiiXNzRaodiwgGJce8IDJr4/TQ==",
+      "version": "2.43.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.43.0-alpha.3.tgz",
+      "integrity": "sha512-Gj2iTFnPzAj/CE3XQ3CzC+bfsBMU8i2eFzqGYpqXLXlO6xtLXmAqj9zuzRWP5vWUnLNl1ydQ4CawqSndk9UPhg==",
       "dependencies": {
         "@gisce/conscheck": "1.0.9",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.43.0-alpha.2",
+    "@gisce/ooui": "2.43.0-alpha.3",
     "@gisce/react-formiga-components": "1.18.0-alpha.2",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.43.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.43.0-alpha.3).