### PR TITLE
update gisce/react-formiga-components to v1.19.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.43.0-alpha.3",
-        "@gisce/react-formiga-components": "1.18.0-alpha.2",
+        "@gisce/react-formiga-components": "1.19.0-alpha.1",
         "@gisce/react-formiga-table": "1.17.0-alpha.6",
         "@monaco-editor/react": "^4.4.5",
         "@tanstack/react-virtual": "^3.13.12",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.18.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.18.0-alpha.2.tgz",
-      "integrity": "sha512-DaDAI3YQznfXSlsBwjwlhtTjk15cAauaLQVEqwFWhch1GmUwptExtCPGTAGJ6p2hxJ/SY/UbzURJiRTdn7VJWA==",
+      "version": "1.19.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.19.0-alpha.1.tgz",
+      "integrity": "sha512-lxxEUjYoCgjT10mUXW/SanXYLJskDHJ0TUpZPb+8xeu2ufbiuA5YtOu3CJFsekzC7b55Oh6lda6BT4vTcvSGew==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.43.0-alpha.3",
-    "@gisce/react-formiga-components": "1.18.0-alpha.2",
+    "@gisce/react-formiga-components": "1.19.0-alpha.1",
     "@gisce/react-formiga-table": "1.17.0-alpha.6",
     "@monaco-editor/react": "^4.4.5",
     "@tanstack/react-virtual": "^3.13.12",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.19.0-alpha.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.19.0-alpha.1).