### PR TITLE
update gisce/ooui to v2.44.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.1.1",
-        "@gisce/ooui": "2.43.0",
+        "@gisce/ooui": "2.44.0",
         "@gisce/react-formiga-components": "1.18.0",
         "@gisce/react-formiga-table": "1.16.2",
         "@monaco-editor/react": "^4.4.5",
@@ -2387,12 +2387,9 @@
       }
     },
     "node_modules/@gisce/conscheck": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.0.9.tgz",
-      "integrity": "sha512-lEC0ShBY/klknvK1dZqRz4RIJxCuI0UJOI8KQMI/os+48U3qtpE+1pGQbxywhmNHVssKQRo2qOwDRu+zNZm6ag==",
-      "engines": {
-        "node": "20.5.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gisce/conscheck/-/conscheck-1.1.0.tgz",
+      "integrity": "sha512-48DLq6RyC9krV7akW8HYdCMU2Ra8UrNZztQAJJpsMk8TbhZBAOfjEKmrYNC04yblzSDIfUkBVK9jPN0ZXQMK4w=="
     },
     "node_modules/@gisce/fiber-diagram": {
       "version": "2.1.1",
@@ -2414,17 +2411,14 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.43.0.tgz",
-      "integrity": "sha512-6vhXydrkTjbS02XXqw/HZDmle8Mg11SW0KkwXYrtRTQYypAaGzDDjvMkwq/ANH4rtZhPUKhViPbC5PMBQ/Bx0A==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.44.0.tgz",
+      "integrity": "sha512-XU2oclTLU/uyoRM8AQ0TkpVPtStz+uSi0vEvMF2TKAOU88NplCjmVURRu8soQuh0UQN1iCmtDEtJIcrLTMR+Fw==",
       "dependencies": {
-        "@gisce/conscheck": "1.0.9",
+        "@gisce/conscheck": "1.1.0",
         "html-entities": "^2.3.3",
         "moment": "^2.29.3",
         "txml": "^5.1.1"
-      },
-      "engines": {
-        "node": "20.5.0"
       }
     },
     "node_modules/@gisce/react-formiga-components": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.1.1",
-    "@gisce/ooui": "2.43.0",
+    "@gisce/ooui": "2.44.0",
     "@gisce/react-formiga-components": "1.18.0",
     "@gisce/react-formiga-table": "1.16.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.44.0](https://github.com/gisce/ooui/releases/tag/v2.44.0).