### PR TITLE
update gisce/react-formiga-table to v1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.1.1",
         "@gisce/ooui": "2.43.0",
         "@gisce/react-formiga-components": "1.18.0",
-        "@gisce/react-formiga-table": "1.16.2",
+        "@gisce/react-formiga-table": "1.17.0",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2513,9 +2513,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.16.2.tgz",
-      "integrity": "sha512-mPb69ozEQFSZ17xsgNzkJtpRUHq7KGaToHRc++DYUjqXLzMh52/LZWupqAgvE3mEQSsf3e/QoCgvktKqJ3pQbA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.17.0.tgz",
+      "integrity": "sha512-4jWSUVFUht+Oi8SK+T0RmApcNG8WKDuyZwEB955Sr9Hj+YPtdV/1J+tfH9LXzmDjq+T+0we0UTZjQs/hZ7D4VQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",
@@ -2529,9 +2529,6 @@
         "use-custom-compare": "^1.4.0",
         "use-deep-compare": "^1.2.1",
         "use-deep-compare-effect": "^1.8.1"
-      },
-      "engines": {
-        "node": "20.5.0"
       },
       "peerDependencies": {
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.1.1",
     "@gisce/ooui": "2.43.0",
     "@gisce/react-formiga-components": "1.18.0",
-    "@gisce/react-formiga-table": "1.16.2",
+    "@gisce/react-formiga-table": "1.17.0",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.17.0](https://github.com/gisce/react-formiga-table/releases/tag/v1.17.0).