### PR TITLE
update gisce/react-formiga-components to v1.20.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.2.0",
         "@gisce/ooui": "2.44.0",
-        "@gisce/react-formiga-components": "1.19.0",
+        "@gisce/react-formiga-components": "1.20.0-alpha.1",
         "@gisce/react-formiga-table": "1.17.0",
         "@monaco-editor/react": "^4.4.5",
         "@tanstack/react-virtual": "^3.13.12",
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.19.0.tgz",
-      "integrity": "sha512-La5TKl0xuoOHFpJxPd32Wi4keEgjyttJfg9EjWenEyOKe62yhIIuiJaZ6fuMi1gqyKHwPmpuIZCxylcCSkmeRA==",
+      "version": "1.20.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.20.0-alpha.1.tgz",
+      "integrity": "sha512-6ve5OIgJvE+IG/1J591aDWJyjQ/+dVzvwIhJ6X2f/I3yW+vq/ZOjSugC2IRg7QYe6M+G2UhZaXy+tpZlWK/R6Q==",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@tabler/icons-react": "^3.31.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.2.0",
     "@gisce/ooui": "2.44.0",
-    "@gisce/react-formiga-components": "1.19.0",
+    "@gisce/react-formiga-components": "1.20.0-alpha.1",
     "@gisce/react-formiga-table": "1.17.0",
     "@monaco-editor/react": "^4.4.5",
     "@tanstack/react-virtual": "^3.13.12",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.20.0-alpha.1](https://github.com/gisce/react-formiga-components/releases/tag/v1.20.0-alpha.1).