### PR TITLE
update gisce/ooui to v2.45.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.2.0",
-        "@gisce/ooui": "2.44.0",
+        "@gisce/ooui": "2.45.0-alpha.1",
         "@gisce/react-formiga-components": "1.19.0",
         "@gisce/react-formiga-table": "1.17.0",
         "@monaco-editor/react": "^4.4.5",
@@ -2203,9 +2203,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.44.0",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.44.0.tgz",
-      "integrity": "sha512-XU2oclTLU/uyoRM8AQ0TkpVPtStz+uSi0vEvMF2TKAOU88NplCjmVURRu8soQuh0UQN1iCmtDEtJIcrLTMR+Fw==",
+      "version": "2.45.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.45.0-alpha.1.tgz",
+      "integrity": "sha512-Kmut1JIk4AsSUiPDUj6v32EOOM11WKEmhd2pRy99Fx+2Hv/KR4KLA3Ia8tXP6tTN2OQCQpr+rXWPvIx3svxo9A==",
       "dependencies": {
         "@gisce/conscheck": "1.1.0",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.2.0",
-    "@gisce/ooui": "2.44.0",
+    "@gisce/ooui": "2.45.0-alpha.1",
     "@gisce/react-formiga-components": "1.19.0",
     "@gisce/react-formiga-table": "1.17.0",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.45.0-alpha.1](https://github.com/gisce/ooui/releases/tag/v2.45.0-alpha.1).