### PR TITLE
update gisce/react-formiga-table to v1.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.2.0",
         "@gisce/ooui": "2.44.0",
         "@gisce/react-formiga-components": "1.19.0",
-        "@gisce/react-formiga-table": "1.17.0",
+        "@gisce/react-formiga-table": "1.17.1",
         "@monaco-editor/react": "^4.4.5",
         "@types/deep-equal": "^1.0.4",
         "antd": "5.25.1",
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.17.0.tgz",
-      "integrity": "sha512-4jWSUVFUht+Oi8SK+T0RmApcNG8WKDuyZwEB955Sr9Hj+YPtdV/1J+tfH9LXzmDjq+T+0we0UTZjQs/hZ7D4VQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.17.1.tgz",
+      "integrity": "sha512-5QzTGAviD7g1IBV3R7biU7YiGaxmlaU4Dmi50oqJGtH0B6/qFnFvjtVQze32Ty/pH0+xkY/eIN/RcoAcNA1G3A==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@gisce/fiber-diagram": "2.2.0",
     "@gisce/ooui": "2.44.0",
     "@gisce/react-formiga-components": "1.19.0",
-    "@gisce/react-formiga-table": "1.17.0",
+    "@gisce/react-formiga-table": "1.17.1",
     "@monaco-editor/react": "^4.4.5",
     "@types/deep-equal": "^1.0.4",
     "antd": "5.25.1",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.17.1](https://github.com/gisce/react-formiga-table/releases/tag/v1.17.1).