### PR TITLE
feat(kanban): add Clear selection link in SearchTreeHeader

### DIFF
--- a/src/locales/ca_ES.ts
+++ b/src/locales/ca_ES.ts
@@ -160,4 +160,5 @@ export default {
   set_column_limit: "Establir límit de columna",
   column_limit: "Límit de columna",
   column_limit_description: "Un límit al nombre d'elements en una columna",
+  clearSelection: "Netejar selecció",
 };

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -157,4 +157,5 @@ export default {
   set_column_limit: "Set column limit",
   column_limit: "Column limit",
   column_limit_description: "A limit on the number of items in a column",
+  clearSelection: "Clear selection",
 };

--- a/src/locales/es_ES.ts
+++ b/src/locales/es_ES.ts
@@ -163,4 +163,5 @@ export default {
     "Un límite en el número de elementos en una columna",
   openInListView: "Abrir en vista de lista",
   createNewRecord: "Crear un nuevo registro",
+  clearSelection: "Limpiar selección",
 };

--- a/src/views/actionViews/KanbanActionView.tsx
+++ b/src/views/actionViews/KanbanActionView.tsx
@@ -405,6 +405,7 @@ const KanbanActionViewComponent = (props: KanbanActionViewProps) => {
         <SearchTreeHeader
           selectedRowKeys={selectedRowKeys}
           totalRows={totalRows}
+          onClearSelection={clearSelection}
           customMiddleComponent={
             shouldShowNameSearchWarning ? (
               <NameSearchWarning

--- a/src/widgets/views/SearchTreeHeader.tsx
+++ b/src/widgets/views/SearchTreeHeader.tsx
@@ -65,7 +65,7 @@ const SearchTreeSelectionSummary = ({
   const clearSelectionLink = onClearSelection ? (
     <>
       {" "}
-      | <Link onClick={onClearSelection}>{t("clearSelection")}</Link>
+      - <Link onClick={onClearSelection}>{t("clearSelection")}</Link>
     </>
   ) : null;
 

--- a/src/widgets/views/SearchTreeHeader.tsx
+++ b/src/widgets/views/SearchTreeHeader.tsx
@@ -1,18 +1,20 @@
 import { useLocale } from "@gisce/react-formiga-components";
 import { Row, Col, Spin, Typography } from "antd";
 import { ReactNode } from "react";
-const { Text } = Typography;
+const { Text, Link } = Typography;
 
 export type SearchTreeHeaderProps = {
   totalRows?: number | null;
   selectedRowKeys: number[];
   customMiddleComponent?: ReactNode;
+  onClearSelection?: () => void;
 };
 
 export const SearchTreeHeader = ({
   totalRows,
   selectedRowKeys,
   customMiddleComponent,
+  onClearSelection,
 }: SearchTreeHeaderProps) => {
   const { t } = useLocale();
 
@@ -27,7 +29,10 @@ export const SearchTreeHeader = ({
       style={{ height: 40, maxHeight: 40, overflow: "hidden" }}
     >
       <Col span={sideColSpan}>
-        <SearchTreeSelectionSummary selectedRowKeys={selectedRowKeys} />
+        <SearchTreeSelectionSummary
+          selectedRowKeys={selectedRowKeys}
+          onClearSelection={onClearSelection}
+        />
       </Col>
       {customMiddleComponent && (
         <Col span={middleColSpan} className="text-center">
@@ -50,15 +55,25 @@ export const SearchTreeHeader = ({
 
 const SearchTreeSelectionSummary = ({
   selectedRowKeys,
+  onClearSelection,
 }: {
   selectedRowKeys: number[];
+  onClearSelection?: () => void;
 }) => {
   const { t } = useLocale();
+
+  const clearSelectionLink = onClearSelection ? (
+    <>
+      {" "}
+      | <Link onClick={onClearSelection}>{t("clearSelection")}</Link>
+    </>
+  ) : null;
+
   if (selectedRowKeys.length === 1) {
     return (
       <>
         1 {t("selectedRegisters")} - (id:{" "}
-        <Text copyable>{selectedRowKeys[0]}</Text>)
+        <Text copyable>{selectedRowKeys[0]}</Text>){clearSelectionLink}
       </>
     );
   } else if (selectedRowKeys.length > 1) {
@@ -70,6 +85,7 @@ const SearchTreeSelectionSummary = ({
             text: selectedRowKeys.join(", "),
           }}
         ></Text>
+        {clearSelectionLink}
       </>
     );
   }


### PR DESCRIPTION
## Summary

Add a "Clear selection" link that appears after the copy icon in the selection summary when viewing a Kanban view. The link allows users to quickly clear all selected cards.

### Changes
- Add `onClearSelection` optional prop to `SearchTreeHeader` component
- Display "| Clear selection" link when `onClearSelection` is provided
- Pass `clearSelection` callback from `KanbanActionView` to `SearchTreeHeader`
- Add translations for `clearSelection` in en_US, es_ES, and ca_ES

## Test plan
- [ ] Open a Kanban view
- [ ] Select one or more cards
- [ ] Verify "| Clear selection" link appears after the copy icon
- [ ] Click the link and verify the selection is cleared

## Related
Closes gisce/webclient#963

---
Generated with [Claude Code](https://claude.ai/code)