### PR TITLE
update gisce/react-formiga-components to v1.20.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.2.0",
         "@gisce/ooui": "2.45.0-alpha.1",
-        "@gisce/react-formiga-components": "1.20.0-alpha.3",
+        "@gisce/react-formiga-components": "1.20.0-alpha.4",
         "@gisce/react-formiga-table": "1.17.0",
         "@monaco-editor/react": "^4.4.5",
         "@tanstack/react-virtual": "^3.13.12",
@@ -2250,9 +2250,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-components": {
-      "version": "1.20.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.20.0-alpha.3.tgz",
-      "integrity": "sha512-ofvAcC47y5KvZ9XlPHa0tlUVn4fytqedEJqm5VuvVSzqb/BvHeCi31UqoJK3gJv6R5ErzO0enPks/STPmtbyNg==",
+      "version": "1.20.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-components/-/react-formiga-components-1.20.0-alpha.4.tgz",
+      "integrity": "sha512-B5je6v85k9J+i0oBsO+oJ3Fl8WvjJ2xUMt28KByOb+7o8NShh7rqWOiAXWG6oTsAHEGNMqvMcdJxm/Qs5Xnnmg==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.2.0",
     "@gisce/ooui": "2.45.0-alpha.1",
-    "@gisce/react-formiga-components": "1.20.0-alpha.3",
+    "@gisce/react-formiga-components": "1.20.0-alpha.4",
     "@gisce/react-formiga-table": "1.17.0",
     "@monaco-editor/react": "^4.4.5",
     "@tanstack/react-virtual": "^3.13.12",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-components](https://github.com/gisce/react-formiga-components) to [v1.20.0-alpha.4](https://github.com/gisce/react-formiga-components/releases/tag/v1.20.0-alpha.4).