### PR TITLE
update gisce/ooui to v2.46.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.2.0",
-        "@gisce/ooui": "2.46.0-alpha.1",
+        "@gisce/ooui": "2.46.0-alpha.3",
         "@gisce/react-formiga-components": "1.20.0",
         "@gisce/react-formiga-table": "1.18.0-alpha.1",
         "@monaco-editor/react": "^4.4.5",
@@ -2416,13 +2416,12 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.46.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.46.0-alpha.1.tgz",
-      "integrity": "sha512-b+Ubx5hYmhtm7w9OGqU3ItV5LMz3k0IKoWyNxAT8REJq0RKph2svaYByOeschUQ/UFm3VevZ9Om61ZvpJ9e72Q==",
+      "version": "2.46.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.46.0-alpha.3.tgz",
+      "integrity": "sha512-kXYXZp/CHAeqvgIfgljZ32jU2TCBE3vEGK56ovDvLD6rqVhm8l059NjwyKGjd+XMFydc1DDn1LfxDLtmu/dzRg==",
       "dependencies": {
         "@gisce/conscheck": "1.1.0",
         "html-entities": "^2.3.3",
-        "json-with-bigint": "^3.5.3",
         "moment": "^2.29.3",
         "txml": "^5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.2.0",
-    "@gisce/ooui": "2.46.0-alpha.1",
+    "@gisce/ooui": "2.46.0-alpha.3",
     "@gisce/react-formiga-components": "1.20.0",
     "@gisce/react-formiga-table": "1.18.0-alpha.1",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.46.0-alpha.3](https://github.com/gisce/ooui/releases/tag/v2.46.0-alpha.3).