### PR TITLE
update gisce/react-formiga-table to v1.18.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@gisce/fiber-diagram": "2.2.0",
         "@gisce/ooui": "2.46.0-alpha.3",
         "@gisce/react-formiga-components": "1.20.0",
-        "@gisce/react-formiga-table": "1.18.0-alpha.2",
+        "@gisce/react-formiga-table": "1.18.0-alpha.3",
         "@monaco-editor/react": "^4.4.5",
         "@tanstack/react-virtual": "^3.13.12",
         "@types/deep-equal": "^1.0.4",
@@ -2517,9 +2517,9 @@
       }
     },
     "node_modules/@gisce/react-formiga-table": {
-      "version": "1.18.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.18.0-alpha.2.tgz",
-      "integrity": "sha512-Vp/xWRgJNJyvHdZy1xme8+MXhoFuy7dE6hsPR2QeTIgjCnVZW4sYb8VNfHpOl91riD5sKhpoaWgDTGy8fzifyA==",
+      "version": "1.18.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gisce/react-formiga-table/-/react-formiga-table-1.18.0-alpha.3.tgz",
+      "integrity": "sha512-geuHPFPL0GMY6ml7SNSQ2Y+t4vDXSbSMKgM7jk7jl7IIxx7SJPMMclnXMhiGX3Nh100d6l9sHqS/rR3Xrb/GMQ==",
       "dependencies": {
         "ag-grid-community": "^31.2.1",
         "ag-grid-react": "^31.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@gisce/fiber-diagram": "2.2.0",
     "@gisce/ooui": "2.46.0-alpha.3",
     "@gisce/react-formiga-components": "1.20.0",
-    "@gisce/react-formiga-table": "1.18.0-alpha.2",
+    "@gisce/react-formiga-table": "1.18.0-alpha.3",
     "@monaco-editor/react": "^4.4.5",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/deep-equal": "^1.0.4",


### PR DESCRIPTION
This PR updates [gisce/react-formiga-table](https://github.com/gisce/react-formiga-table) to [v1.18.0-alpha.3](https://github.com/gisce/react-formiga-table/releases/tag/v1.18.0-alpha.3).