### PR TITLE
Use ProgressBar from reac-formiga-components

### DIFF
--- a/src/widgets/base/ProgressBar.tsx
+++ b/src/widgets/base/ProgressBar.tsx
@@ -1,8 +1,6 @@
-import { Progress } from "antd";
 import Field from "@/common/Field";
 import { WidgetProps } from "@/types";
-import styled from "styled-components";
-import { useRef } from "react";
+import { ProgressBarValue } from "@gisce/react-formiga-components";
 
 export const ProgressBar = (props: WidgetProps) => {
   return (
@@ -13,48 +11,5 @@ export const ProgressBar = (props: WidgetProps) => {
 };
 
 export const ProgressBarInput = ({ value }: { value?: number }) => {
-  const lastValidValueRef = useRef<number>(0);
-
-  if (value !== undefined) {
-    lastValidValueRef.current = value;
-  }
-
-  const displayValue = value !== undefined ? value : lastValidValueRef.current;
-
-  const textValue = `${displayValue.toLocaleString("en-US", {
-    minimumIntegerDigits: 1,
-    maximumFractionDigits: 4,
-    useGrouping: false,
-  })}%`;
-
-  return (
-    <StyledProgressContainer>
-      <StyledProgress percent={displayValue} />
-      <StyledText>{textValue}</StyledText>
-    </StyledProgressContainer>
-  );
+  return <ProgressBarValue value={value} />;
 };
-
-const StyledProgressContainer = styled.div`
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-width: 0;
-`;
-
-const StyledProgress = styled(Progress)`
-  flex: 1;
-  min-width: 0;
-  .ant-progress-outer {
-    margin-right: 0px;
-    padding-right: 0px;
-  }
-  .ant-progress-text {
-    display: none;
-  }
-`;
-
-const StyledText = styled.div`
-  padding-left: 10px;
-  white-space: nowrap;
-`;


### PR DESCRIPTION
This pull request refactors the `ProgressBar` widget to use the `ProgressBarValue` component from the `@gisce/react-formiga-components` library, replacing the previous custom implementation and removing unused code and dependencies.

**Component refactor:**

* Replaced the custom progress bar implementation in `ProgressBarInput` with the `ProgressBarValue` component for improved consistency and maintainability.

**Dependency cleanup:**

* Removed imports of `antd`, `styled-components`, and related custom styling, as they are no longer needed after switching to `ProgressBarValue`.