### PR TITLE
update gisce/ooui to v2.46.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@gisce/fiber-diagram": "2.2.0",
-        "@gisce/ooui": "2.46.0-alpha.4",
+        "@gisce/ooui": "2.46.0-alpha.5",
         "@gisce/react-formiga-components": "1.21.0",
         "@gisce/react-formiga-table": "1.17.2",
         "@monaco-editor/react": "^4.4.5",
@@ -2416,9 +2416,9 @@
       }
     },
     "node_modules/@gisce/ooui": {
-      "version": "2.46.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.46.0-alpha.4.tgz",
-      "integrity": "sha512-1kpK9Ntbtu/aR6p3Z61lctnlSeIAj9ARCjI9ZfjYL6oOW4yn2b4EvdPO0JCHOD/BjiRi2oZl/hcrl3LtAgAAuw==",
+      "version": "2.46.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@gisce/ooui/-/ooui-2.46.0-alpha.5.tgz",
+      "integrity": "sha512-jjUc677NKND4PD9CK2DQDKJ+At4WJWffM2P7RsxdEjLsQzsjX0CzYfn88PQUVQ7+O38S9190epnXNmAnZhom5A==",
       "dependencies": {
         "@gisce/conscheck": "1.1.0",
         "html-entities": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@gisce/fiber-diagram": "2.2.0",
-    "@gisce/ooui": "2.46.0-alpha.4",
+    "@gisce/ooui": "2.46.0-alpha.5",
     "@gisce/react-formiga-components": "1.21.0",
     "@gisce/react-formiga-table": "1.17.2",
     "@monaco-editor/react": "^4.4.5",


### PR DESCRIPTION
This PR updates [gisce/ooui](https://github.com/gisce/ooui) to [v2.46.0-alpha.5](https://github.com/gisce/ooui/releases/tag/v2.46.0-alpha.5).